### PR TITLE
add show_score_thr.

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -30,7 +30,10 @@ def parse_args():
     parser.add_argument('--eval', type=str, nargs='+', help='eval types')
     parser.add_argument('--show', action='store_true', help='show results')
     parser.add_argument(
-        '--show-score-thr', default=0.3, help='minimum score of bboxes to be shown')
+        '--show-score-thr',
+        type=float,
+        default=0.3,
+        help='score threshold (default: 0.3)')
     parser.add_argument(
         '--show-dir', help='directory where painted images will be saved')
     parser.add_argument(

--- a/tools/test.py
+++ b/tools/test.py
@@ -30,6 +30,8 @@ def parse_args():
     parser.add_argument('--eval', type=str, nargs='+', help='eval types')
     parser.add_argument('--show', action='store_true', help='show results')
     parser.add_argument(
+        '--show-score-thr', default=0.3, help='minimum score of bboxes to be shown')
+    parser.add_argument(
         '--show-dir', help='directory where painted images will be saved')
     parser.add_argument(
         '--gpu-collect',


### PR DESCRIPTION
in tools/test.py, lost one args "show_score_thr". 
```
    if not distributed:
        model = MMDataParallel(model, device_ids=[0])
        outputs = single_gpu_test(model, data_loader, args.show, args.show_dir,
                                  args.show_score_thr)
```

I search the project and find this in show_result(), and set default as 0.3.