### PR TITLE
fix draw rectangle

### DIFF
--- a/demo/demo_sot.py
+++ b/demo/demo_sot.py
@@ -21,7 +21,7 @@ def main():
     parser.add_argument(
         '--color', default=(0, 255, 0), help='Color of tracked bbox lines.')
     parser.add_argument(
-        '--thickness', default=3, help='Thickness of bbox lines.')
+        '--thickness', default=3, type=int, help='Thickness of bbox lines.')
     args = parser.parse_args()
 
     # build the model from a config file and a checkpoint file


### PR DESCRIPTION
Drawing a rectangle requires the thickness to be an integer, but the `arg.thickness `given is a string by default.