### PR TITLE
Update train.py

### DIFF
--- a/mmtrack/apis/train.py
+++ b/mmtrack/apis/train.py
@@ -1,9 +1,8 @@
 import torch
 from mmcv.parallel import MMDataParallel, MMDistributedDataParallel
 from mmcv.runner import (HOOKS, DistSamplerSeedHook, EpochBasedRunner,
-                         OptimizerHook, build_optimizer)
+                         OptimizerHook, build_optimizer, Fp16OptimizerHook)
 from mmcv.utils import build_from_cfg
-from mmdet.core import Fp16OptimizerHook
 from mmdet.datasets import build_dataset
 
 from mmtrack.core import DistEvalHook, EvalHook


### PR DESCRIPTION
I had an error with running demo because in the train.py file, it wants to import Fp16OptimizerHook from mmdet.core but gets an error,
I change the code to import this method from mmcv.runner and the error fixed.