### PR TITLE
utilize mmcv collect_env (add windows support)

### DIFF
--- a/mmtrack/utils/collect_env.py
+++ b/mmtrack/utils/collect_env.py
@@ -7,7 +7,7 @@ import mmtrack
 def collect_env():
     """Collect the information of the running environments."""
     env_info = collect_base_env()
-    env_info['mmtrack'] = mmtrack.__version__ + '+' + get_git_hash()[:7]
+    env_info['MMTracking'] = mmtrack.__version__ + '+' + get_git_hash()[:7]
     return env_info
 
 

--- a/mmtrack/utils/collect_env.py
+++ b/mmtrack/utils/collect_env.py
@@ -1,59 +1,13 @@
-import os.path as osp
-import subprocess
-import sys
-from collections import defaultdict
-
-import cv2
-import mmcv
-import torch
-import torchvision
+from mmcv.utils import collect_env as collect_base_env
+from mmcv.utils import get_git_hash
 
 import mmtrack
 
 
 def collect_env():
     """Collect the information of the running environments."""
-    env_info = {}
-    env_info['sys.platform'] = sys.platform
-    env_info['Python'] = sys.version.replace('\n', '')
-
-    cuda_available = torch.cuda.is_available()
-    env_info['CUDA available'] = cuda_available
-
-    if cuda_available:
-        from torch.utils.cpp_extension import CUDA_HOME
-        env_info['CUDA_HOME'] = CUDA_HOME
-
-        if CUDA_HOME is not None and osp.isdir(CUDA_HOME):
-            try:
-                nvcc = osp.join(CUDA_HOME, 'bin/nvcc')
-                nvcc = subprocess.check_output(
-                    f'"{nvcc}" -V | tail -n1', shell=True)
-                nvcc = nvcc.decode('utf-8').strip()
-            except subprocess.SubprocessError:
-                nvcc = 'Not Available'
-            env_info['NVCC'] = nvcc
-
-        devices = defaultdict(list)
-        for k in range(torch.cuda.device_count()):
-            devices[torch.cuda.get_device_name(k)].append(str(k))
-        for name, devids in devices.items():
-            env_info['GPU ' + ','.join(devids)] = name
-
-    gcc = subprocess.check_output('gcc --version | head -n1', shell=True)
-    gcc = gcc.decode('utf-8').strip()
-    env_info['GCC'] = gcc
-
-    env_info['PyTorch'] = torch.__version__
-    env_info['PyTorch compiling details'] = torch.__config__.show()
-
-    env_info['TorchVision'] = torchvision.__version__
-
-    env_info['OpenCV'] = cv2.__version__
-
-    env_info['MMCV'] = mmcv.__version__
-    env_info['mmtrack'] = mmtrack.__version__
-
+    env_info = collect_base_env()
+    env_info['mmtrack'] = mmtrack.__version__ + '+' + get_git_hash()[:7]
     return env_info
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ line_length = 79
 multi_line_output = 0
 known_standard_library = setuptools
 known_first_party = mmtrack
-known_third_party = addict,cv2,dotty_dict,matplotlib,mmcls,mmcv,mmdet,motmetrics,numpy,pandas,pycocotools,pytest,scipy,seaborn,torch,torchvision,tqdm
+known_third_party = addict,cv2,dotty_dict,matplotlib,mmcls,mmcv,mmdet,motmetrics,numpy,pandas,pycocotools,pytest,scipy,seaborn,torch,tqdm
 no_lines_before = STDLIB,LOCALFOLDER
 default_section = THIRDPARTY
 


### PR DESCRIPTION
- This PR updates [mmtracking/utils/collect_env.py](https://github.com/open-mmlab/mmtracking/blob/master/mmtrack/utils/collect_env.py) with [mmdetection/utils/collect_env.py](https://github.com/open-mmlab/mmdetection/blob/master/mmdet/utils/collect_env.py) by utilizing [mmcv/collect_env](https://github.com/open-mmlab/mmcv/blob/master/mmcv/utils/env.py)

- It also adds windows support to [training script](https://github.com/open-mmlab/mmtracking/blob/master/tools/train.py)