### PR TITLE
Update install.md

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -5,8 +5,8 @@
 - PyTorch 1.3+
 - CUDA 9.2+ (If you build PyTorch from source, CUDA 9.0 is also compatible)
 - GCC 5+
-- [MMCV](https://mmcv.readthedocs.io/en/latest/#installation) 1.2.4
-- [MMDetection](https://mmdetection.readthedocs.io/en/latest/#installation) 2.8.0
+- [MMCV](https://mmcv.readthedocs.io/en/latest/#installation) 1.3.4
+- [MMDetection](https://mmdetection.readthedocs.io/en/latest/#installation) 2.12.0
 
 ## Installation
 
@@ -32,7 +32,7 @@
     PyTorch 1.5, you need to install the prebuilt PyTorch with CUDA 10.1.
 
     ```shell
-    conda install pytorch cudatoolkit=10.1 torchvision -c pytorch
+    conda install pytorch==1.5 cudatoolkit=10.1 torchvision -c pytorch
     ```
 
     `E.g. 2` If you have CUDA 9.2 installed under `/usr/local/cuda` and would like to install


### PR DESCRIPTION
The version specified in the prerequisites doesn't work.
`MMCV 1.2.4
MMDetection 2.8.0`
The program complains that "AssertionError: MMCV==1.2.4 is used but incompatible. Please install mmcv>=1.3.0, <=1.5.0."
But when I change to mmcv==1.3.0, it complains "AssertionError: MMCV==1.3.0 is used but incompatible. Please install mmcv>=1.2.4, <=1.3." ...
Finally, I use "pip install mmcv-full" and "pip install mmdet". It automatically installs "mmcv-full==1.3.4" and "mmdet==2.12.0".And this finally worked...