### PR TITLE
[Fix] fix evaluation bug in eval_hooks.py

### DIFF
--- a/mmtrack/core/evaluation/eval_hooks.py
+++ b/mmtrack/core/evaluation/eval_hooks.py
@@ -9,7 +9,7 @@ class EvalHook(_EvalHook):
     detailed docstring."""
 
     def after_train_epoch(self, runner):
-        if not self.evaluation_flag(runner):
+        if not self._should_evaluate(runner):
             return
         if self.dataloader.dataset.load_as_video:
             from mmtrack.apis import single_gpu_test
@@ -24,7 +24,7 @@ class DistEvalHook(_DistEvalHook):
     detailed docstring."""
 
     def after_train_epoch(self, runner):
-        if not self.evaluation_flag(runner):
+        if not self._should_evaluate(runner):
             return
         if self.dataloader.dataset.load_as_video:
             from mmtrack.apis import multi_gpu_test

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -457,13 +457,10 @@ def test_evaluation_hook(EvalHookParam):
     runner.run([dataloader], [('train', 1)], 2)
     assert evalhook.evaluate.call_count == 3  # before epoch1 and after e1 & e2
 
+    # the evaluation start epoch cannot be less than 0
     runner = _build_demo_runner()
-    with pytest.warns(UserWarning):
-        evalhook = EvalHookParam(dataloader, start=-2)
-    evalhook.evaluate = MagicMock()
-    runner.register_hook(evalhook)
-    runner.run([dataloader], [('train', 1)], 2)
-    assert evalhook.evaluate.call_count == 3  # before epoch1 and after e1 & e2
+    with pytest.raises(ValueError):
+        EvalHookParam(dataloader, start=-2)
 
     # 6. resuming from epoch i, start = x (x<=i), interval =1: perform
     #    evaluation after each epoch and before the first epoch.


### PR DESCRIPTION
Hi~
This PR fix the following bugs:
  1. The `evaluation_flag` method in EvalHook has been replaced by  `_should_evaluate`.
  2. The evaluation start epoch cannot be less than 0.