### PR TITLE
[Fix] fix the compatibility bug of MMTracking, MMCV, and MMDetection version

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -10,9 +10,12 @@
 
 The compatible MMTracking, MMCV, and MMDetection versions are as below. Please install the correct version to avoid installation issues.
 
-|  MMTracking version |       MMCV version       |  MMDetection version |
-|:-------------------:|:------------------------:|:--------------------:|
-|        master       | mmcv-full>=1.3.3, <1.4.0 |  MMDetection=2.13.0  |
+|  MMTracking version |       MMCV version       |      MMDetection version      |
+|:-------------------:|:------------------------:|:-----------------------------:|
+|    0.6.0 (master)   | mmcv-full>=1.3.3, <1.4.0 |  MMDetection=2.14.0 (master)  |
+|        0.5.2        | mmcv-full>=1.3.3, <1.4.0 |       MMDetection=2.12.0      |
+
+NOTE: The versions denoted with master will be released at the end of June, 2021.
 
 ## Installation
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -5,8 +5,14 @@
 - PyTorch 1.3+
 - CUDA 9.2+ (If you build PyTorch from source, CUDA 9.0 is also compatible)
 - GCC 5+
-- [MMCV](https://mmcv.readthedocs.io/en/latest/#installation) 1.3.4
-- [MMDetection](https://mmdetection.readthedocs.io/en/latest/#installation) 2.12.0
+- [MMCV](https://mmcv.readthedocs.io/en/latest/#installation)
+- [MMDetection](https://mmdetection.readthedocs.io/en/latest/#installation)
+
+The compatible MMTracking, MMCV, and MMDetection versions are as below. Please install the correct version to avoid installation issues.
+
+|  MMTracking version |       MMCV version       |  MMDetection version |
+|:-------------------:|:------------------------:|:--------------------:|
+|        master       | mmcv-full>=1.3.3, <1.4.0 |  MMDetection=2.13.0  |
 
 ## Installation
 

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,6 +1,6 @@
 dotty_dict
 matplotlib
-mmcls
+mmcls==0.12.0
 mmpycocotools
 motmetrics
 numpy


### PR DESCRIPTION
Hi~
This PR fix the compatibility bug of MMTracking, MMCV, and MMDetection version. Besides, MMClassification version is fixed at 0.12.0.