### PR TITLE
[Fix] fix reid model unitest

### DIFF
--- a/configs/mot/deepsort/deepsort_faster-rcnn_fpn_4e_mot17-private-half.py
+++ b/configs/mot/deepsort/deepsort_faster-rcnn_fpn_4e_mot17-private-half.py
@@ -32,6 +32,9 @@ model = dict(
             fc_channels=1024,
             out_channels=128,
             num_classes=378,
+            loss=dict(type='CrossEntropyLoss', loss_weight=1.0),
+            loss_pairwise=dict(
+                type='TripletLoss', margin=0.3, loss_weight=1.0),
             norm_cfg=dict(type='BN1d'),
             act_cfg=dict(type='ReLU'))),
     tracker=dict(

--- a/configs/mot/tracktor/tracktor_faster-rcnn_r50_fpn_4e_mot17-private-half.py
+++ b/configs/mot/tracktor/tracktor_faster-rcnn_r50_fpn_4e_mot17-private-half.py
@@ -31,6 +31,9 @@ model = dict(
             fc_channels=1024,
             out_channels=128,
             num_classes=378,
+            loss=dict(type='CrossEntropyLoss', loss_weight=1.0),
+            loss_pairwise=dict(
+                type='TripletLoss', margin=0.3, loss_weight=1.0),
             norm_cfg=dict(type='BN1d'),
             act_cfg=dict(type='ReLU'))),
     motion=dict(

--- a/mmtrack/models/reid/linear_reid_head.py
+++ b/mmtrack/models/reid/linear_reid_head.py
@@ -1,10 +1,11 @@
 import warnings
 
 import torch.nn as nn
-from mmcls.models.builder import HEADS, build_loss
+from mmcls.models.builder import HEADS
 from mmcls.models.heads.base_head import BaseHead
 from mmcls.models.losses import Accuracy
 from mmcv.cnn import constant_init, normal_init
+from mmdet.models.builder import build_loss
 
 from .fc_module import FcModule
 

--- a/tests/test_models/test_reid.py
+++ b/tests/test_models/test_reid.py
@@ -5,7 +5,7 @@ from mmtrack.models import REID
 
 
 @pytest.mark.parametrize('model_type', ['BaseReID'])
-def test_load_detections(model_type):
+def test_base_reid(model_type):
     model_class = REID.get(model_type)
     backbone = dict(
         type='ResNet',

--- a/tests/test_models/test_reid.py
+++ b/tests/test_models/test_reid.py
@@ -41,11 +41,17 @@ def test_base_reid(model_type):
     assert outputs.shape == (1, 128)
 
     head['num_classes'] = None
+    # when loss_pairwise is set, num_classes must be a current number
     with pytest.raises(TypeError):
-        # The num_classes must be a current number
         model = model_class(backbone=backbone, neck=neck, head=head)
 
-    head['loss'], head['loss_pairwise'] = None, None
+    head['num_classes'] = 378
+    head['loss'] = None
+    # when loss_pairwise is set, num_classes will be ignored.
+    with pytest.warns(UserWarning):
+        model = model_class(backbone=backbone, neck=neck, head=head)
+
+    head['loss_pairwise'] = None
+    # two losses cannot be none at the same time
     with pytest.raises(ValueError):
-        # Two losses cannot be none at the same time
         model = model_class(backbone=backbone, neck=neck, head=head)


### PR DESCRIPTION
This PR fix the following bug:
1. add `loss`  and `loss_pairwise` to mot config, the default is set to None. https://github.com/open-mmlab/mmtracking/pull/180#discussion_r659271518
2. use mmdet build_loss function. 
3. fix BaseReid model unitest