### PR TITLE
fix a bug where detector is not initialized when training a detector in MOT task

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -66,11 +66,13 @@ def main():
 
     cfg = Config.fromfile(args.config)
 
+    need_init_detector = False
     if cfg.get('USE_MMDET', False):
         from mmdet.apis import train_detector as train_model
         from mmdet.models import build_detector as build_model
         if 'detector' in cfg.model:
             cfg.model = cfg.model.detector
+            need_init_detector = True
     elif cfg.get('USE_MMCLS', False):
         from mmtrack.apis import train_model
         from mmtrack.models import build_reid as build_model
@@ -146,6 +148,10 @@ def main():
         model = build_model(cfg.model)
     if 'detector' in cfg.model:
         model.detector.init_weights()
+    # if True, the model denotes a detector based on Line #75. Therefore, we
+    # need model.init_weights() rather than model.detector.init_weights()
+    if need_init_detector:
+        model.init_weights()
 
     datasets = [build_dataset(cfg.data.train)]
     if len(cfg.workflow) == 2:


### PR DESCRIPTION
Fix a bug where detector is not initialized when training a detector in MOT task.
The way to fix the bug may be a little ugly.
The reason is that MMDet has already supported unified model initialization, while MMTracking has not supported it. 
We will support it in the future.