### PR TITLE
[Docs] add a note for MOT inference

### DIFF
--- a/docs/quick_run.md
+++ b/docs/quick_run.md
@@ -46,6 +46,8 @@ Examples:
 python demo/demo_mot.py configs/mot/deepsort/sort_faster-rcnn_fpn_4e_mot17-private.py --input demo/demo.mp4 --output mot.mp4
 ```
 
+Note: The multiple object tracking model must use the private detectors.
+
 #### Inference SOT models
 
 This script can inference an input video with a single object tracking model.

--- a/docs_zh-CN/quick_run.md
+++ b/docs_zh-CN/quick_run.md
@@ -46,6 +46,8 @@ python demo/demo_mot.py \
 python demo/demo_mot.py configs/mot/deepsort/sort_faster-rcnn_fpn_4e_mot17-private.py --input demo/demo.mp4 --output mot.mp4
 ```
 
+注意：多目标跟踪模型必须使用私有检测器。
+
 ### 使用 SOT 模型进行推理
 
 以下脚本可以使用单目标跟踪模型对一个输入视频进行推理。


### PR DESCRIPTION
This PR adds a note for MOT inference visualization. 
Currently, the multiple object tracking model only support the private detectors in inference visualization(#225). 