### PR TITLE
Use pycocotools instead of mmpycocotools

### DIFF
--- a/configs/vid/temporal_roi_align/selsa_troialign_faster_rcnn_x101_dc5_7e_imagenetvid.py
+++ b/configs/vid/temporal_roi_align/selsa_troialign_faster_rcnn_x101_dc5_7e_imagenetvid.py
@@ -1,4 +1,4 @@
-_base_ = ['./selsa_troi_faster_rcnn_r50_dc5_7e_imagenetvid.py']
+_base_ = ['./selsa_troialign_faster_rcnn_r50_dc5_7e_imagenetvid.py']
 model = dict(
     detector=dict(
         backbone=dict(

--- a/mmtrack/datasets/imagenet_vid_dataset.py
+++ b/mmtrack/datasets/imagenet_vid_dataset.py
@@ -1,6 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from mmdet.datasets import DATASETS
-from pycocotools.coco import COCO
+from mmdet.datasets.api_wrappers import COCO
 
 from .coco_video_dataset import CocoVideoDataset
 from .parsers import CocoVID

--- a/mmtrack/datasets/parsers/coco_video_parser.py
+++ b/mmtrack/datasets/parsers/coco_video_parser.py
@@ -2,7 +2,8 @@
 from collections import defaultdict
 
 import numpy as np
-from pycocotools.coco import COCO, _isArrayLike
+from mmdet.datasets.api_wrappers import COCO
+from pycocotools.coco import _isArrayLike
 
 
 class CocoVID(COCO):

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,9 +1,9 @@
 dotty_dict
 matplotlib
 mmcls>=0.14.0
-mmpycocotools
 motmetrics
 packaging
+pycocotools
 seaborn
 six
 terminaltables


### PR DESCRIPTION
As described in #259 , MMPycocotools is no longer necessary. We use the official pycocotools.