### PR TITLE
Adapt to mmcls >= 0.16.0

### DIFF
--- a/mmtrack/models/reid/base_reid.py
+++ b/mmtrack/models/reid/base_reid.py
@@ -18,7 +18,7 @@ class BaseReID(ImageClassifier):
             # change the shape of label tensor from NxS to NS
             gt_label = gt_label.view(-1)
         x = self.extract_feat(img)
-        head_outputs = self.head.forward_train(x)
+        head_outputs = self.head.forward_train(x[0])
 
         losses = dict()
         reid_loss = self.head.loss(gt_label, *head_outputs)
@@ -30,7 +30,7 @@ class BaseReID(ImageClassifier):
         """Test without augmentation."""
         if img.nelement() > 0:
             x = self.extract_feat(img)
-            head_outputs = self.head.forward_train(x)
+            head_outputs = self.head.forward_train(x[0])
             feats = head_outputs[0]
             return feats
         else:

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,6 +1,6 @@
 dotty_dict
 matplotlib
-mmcls>=0.14.0
+mmcls>=0.16.0
 motmetrics
 packaging
 pycocotools


### PR DESCRIPTION
The type of output in the backbone of `mmcls >= 0.16.0` changes from `Tensor` to `(Tensor, )`.
This PR changes `base_reid.py` in order to adapt to mmcls >= 0.16.0.