### PR TITLE
fix CocoVideoDataset self.__repr__ problem

### DIFF
--- a/mmtrack/datasets/coco_video_dataset.py
+++ b/mmtrack/datasets/coco_video_dataset.py
@@ -4,6 +4,7 @@ import random
 import numpy as np
 from mmcv.utils import print_log
 from mmdet.datasets import DATASETS, CocoDataset
+from terminaltables import AsciiTable
 
 from mmtrack.core import eval_mot
 from mmtrack.utils import get_root_logger
@@ -44,6 +45,50 @@ class CocoVideoDataset(CocoDataset):
         self.test_load_ann = test_load_ann
         super().__init__(*args, **kwargs)
         self.logger = get_root_logger()
+
+    def __repr__(self):
+        """Print the number of instance number."""
+        dataset_type = 'Test' if self.test_mode else 'Train'
+        result = (f'\n{self.__class__.__name__} {dataset_type} dataset '
+                  f'with number of images {len(self)}, '
+                  f'and instance counts: \n')
+        if self.CLASSES is None:
+            result += 'Category names are not provided. \n'
+            return result
+        instance_count = np.zeros(len(self.CLASSES) + 1).astype(int)
+        # count the instance number in each image
+        for idx in range(len(self)):
+            img_info = self.data_infos[idx]
+            label = self.get_ann_info(img_info)['labels']
+            unique, counts = np.unique(label, return_counts=True)
+            if len(unique) > 0:
+                # add the occurrence number to each class
+                instance_count[unique] += counts
+            else:
+                # background is the last index
+                instance_count[-1] += 1
+        # create a table with category count
+        table_data = [['category', 'count'] * 5]
+        row_data = []
+        for cls, count in enumerate(instance_count):
+            if cls < len(self.CLASSES):
+                row_data += [f'{cls} [{self.CLASSES[cls]}]', f'{count}']
+            else:
+                # add the background number
+                row_data += ['-1 background', f'{count}']
+            if len(row_data) == 10:
+                table_data.append(row_data)
+                row_data = []
+        if len(row_data) >= 2:
+            if row_data[-1] == '0':
+                row_data = row_data[:-2]
+            if len(row_data) >= 2:
+                table_data.append([])
+                table_data.append(row_data)
+
+        table = AsciiTable(table_data)
+        result += table.table
+        return result
 
     def load_annotations(self, ann_file):
         """Load annotations from COCO/COCOVID style annotation file.

--- a/mmtrack/datasets/coco_video_dataset.py
+++ b/mmtrack/datasets/coco_video_dataset.py
@@ -46,50 +46,6 @@ class CocoVideoDataset(CocoDataset):
         super().__init__(*args, **kwargs)
         self.logger = get_root_logger()
 
-    def __repr__(self):
-        """Print the number of instance number."""
-        dataset_type = 'Test' if self.test_mode else 'Train'
-        result = (f'\n{self.__class__.__name__} {dataset_type} dataset '
-                  f'with number of images {len(self)}, '
-                  f'and instance counts: \n')
-        if self.CLASSES is None:
-            result += 'Category names are not provided. \n'
-            return result
-        instance_count = np.zeros(len(self.CLASSES) + 1).astype(int)
-        # count the instance number in each image
-        for idx in range(len(self)):
-            img_info = self.data_infos[idx]
-            label = self.get_ann_info(img_info)['labels']
-            unique, counts = np.unique(label, return_counts=True)
-            if len(unique) > 0:
-                # add the occurrence number to each class
-                instance_count[unique] += counts
-            else:
-                # background is the last index
-                instance_count[-1] += 1
-        # create a table with category count
-        table_data = [['category', 'count'] * 5]
-        row_data = []
-        for cls, count in enumerate(instance_count):
-            if cls < len(self.CLASSES):
-                row_data += [f'{cls} [{self.CLASSES[cls]}]', f'{count}']
-            else:
-                # add the background number
-                row_data += ['-1 background', f'{count}']
-            if len(row_data) == 10:
-                table_data.append(row_data)
-                row_data = []
-        if len(row_data) >= 2:
-            if row_data[-1] == '0':
-                row_data = row_data[:-2]
-            if len(row_data) >= 2:
-                table_data.append([])
-                table_data.append(row_data)
-
-        table = AsciiTable(table_data)
-        result += table.table
-        return result
-
     def load_annotations(self, ann_file):
         """Load annotations from COCO/COCOVID style annotation file.
 
@@ -494,3 +450,48 @@ class CocoVideoDataset(CocoDataset):
             eval_results.update(super_eval_results)
 
         return eval_results
+
+    def __repr__(self):
+        """Print the number of instance number."""
+        dataset_type = 'Test' if self.test_mode else 'Train'
+        result = (f'\n{self.__class__.__name__} {dataset_type} dataset '
+                  f'with number of images {len(self)}, '
+                  f'and instance counts: \n')
+        if self.CLASSES is None:
+            result += 'Category names are not provided. \n'
+            return result
+        instance_count = np.zeros(len(self.CLASSES) + 1).astype(int)
+        # count the instance number in each image
+        for idx in range(len(self)):
+            img_info = self.data_infos[idx]
+            label = self.get_ann_info(img_info)['labels']
+            unique, counts = np.unique(label, return_counts=True)
+            if len(unique) > 0:
+                # add the occurrence number to each class
+                instance_count[unique] += counts
+            else:
+                # background is the last index
+                instance_count[-1] += 1
+        # create a table with category count
+        table_data = [['category', 'count'] * 5]
+        row_data = []
+        for cls, count in enumerate(instance_count):
+            if cls < len(self.CLASSES):
+                row_data += [f'{cls} [{self.CLASSES[cls]}]', f'{count}']
+            else:
+                # add the background number
+                row_data += ['-1 background', f'{count}']
+            if len(row_data) == 10:
+                table_data.append(row_data)
+                row_data = []
+        if len(row_data) >= 2:
+            if row_data[-1] == '0':
+                row_data = row_data[:-2]
+            if len(row_data) >= 2:
+                table_data.append([])
+                table_data.append(row_data)
+
+        table = AsciiTable(table_data)
+        result += table.table
+        return result
+


### PR DESCRIPTION
Just overloading the `self.__repr__` in `coco_video_dataset.py`, the only changed line compared with `CustomDatsaet.__repr__` is line 61. 

For now, I can not generally fix the `self.get_ann_info(dict)` to `self.get_ann_info(idx)`, cuz I'm not familiar with the tasks except for VID.

A better general way is reflecting the 'fetch idx' to 'img idx' before using `self.get_ann_info()`

In the VID dataset, key img info can only be fetched by 'fetch idx' from a filtered frame list, `self.data_infos` in which `is_vid_train_frame = train`. 
While ref img can be sampled over all frames. So `self.ref_img_sampling()` can only return 'img idx'.
Both 'fetch idx' and 'img idx' use 'self.get_ann_info(idx)' could not work. I think that is the reason why change the parameters from idx to dict.
So build a index dict in `self.__init__`, reflecting the 'fetch idx' to 'img idx' before using `self.get_ann_info()` may work. But it may affect the other video dataset, so I can not do it now. 

Nevermind if rejected :)