### PR TITLE
[Fix] fix a bug in the converting script of OTB100 dataset 

### DIFF
--- a/docs/dataset.md
+++ b/docs/dataset.md
@@ -197,7 +197,7 @@ python ./tools/convert_datasets/trackingnet/trackingnet2coco.py -i ./data/tracki
 # unzip files in 'data/otb100/zips/*.zip'
 bash ./tools/convert_datasets/otb100/unzip_otb100.sh ./data/otb100
 # generate annotations
-python ./tools/convert_datasets/otb100/otb2coco.py -i ./data/otb100/data -o ./data/otb100/annotations
+python ./tools/convert_datasets/otb100/otb2coco.py -i ./data/otb100 -o ./data/otb100/annotations
 
 # GOT10k
 # unzip 'data/got10k/full_data/test_data.zip', 'data/got10k/full_data/val_data.zip' and files in 'data/got10k/full_data/train_data/*.zip'

--- a/docs_zh-CN/dataset.md
+++ b/docs_zh-CN/dataset.md
@@ -198,7 +198,7 @@ python ./tools/convert_datasets/trackingnet/trackingnet2coco.py -i ./data/tracki
 # 解压目录 'data/otb100/zips' 下的所有 '*.zip' 文件
 bash ./tools/convert_datasets/otb100/unzip_otb100.sh ./data/otb100
 # 生成标注
-python ./tools/convert_datasets/otb100/otb2coco.py -i ./data/otb100/data -o ./data/otb100/annotations
+python ./tools/convert_datasets/otb100/otb2coco.py -i ./data/otb100 -o ./data/otb100/annotations
 
 # GOT10k
 # 解压 'data/got10k/full_data/test_data.zip', 'data/got10k/full_data/val_data.zip' 和 目录'data/got10k/full_data/train_data/' 下的所有 '*.zip' 文件

--- a/tools/convert_datasets/otb100/download_otb100.py
+++ b/tools/convert_datasets/otb100/download_otb100.py
@@ -19,7 +19,7 @@ def download_url(url_savedir_tuple):
     saved_dir = url_savedir_tuple[1]
     video_zip = osp.basename(url)
     if not osp.isdir(saved_dir):
-        os.makedirs(saved_dir)
+        os.makedirs(saved_dir, exist_ok=True)
     saved_file = osp.join(saved_dir, video_zip)
 
     try:

--- a/tools/convert_datasets/otb100/otb2coco.py
+++ b/tools/convert_datasets/otb100/otb2coco.py
@@ -34,6 +34,7 @@ def convert_otb100(otb, ann_dir, save_dir):
         save_dir (str): The path to save `OTB100`.
     """
     records = dict(vid_id=1, img_id=1, ann_id=1, global_instance_id=1)
+    ann_dir = osp.join(ann_dir, 'data')
     videos_list = os.listdir(ann_dir)
     otb['categories'] = [dict(id=0, name=0)]
 

--- a/tools/convert_datasets/otb100/otb2coco.py
+++ b/tools/convert_datasets/otb100/otb2coco.py
@@ -84,7 +84,7 @@ def convert_otb100(otb, ann_dir, save_dir):
                     video_id=records['vid_id'])
                 otb['images'].append(image)
 
-                bbox = list(map(int, re.findall(r'\d+', gt_bbox)))
+                bbox = list(map(int, re.findall(r'-?\d+', gt_bbox)))
                 assert len(bbox) == 4
                 anno_dict = dict(
                     id=records['ann_id'],


### PR DESCRIPTION
Previous bbox coordinate converting can't parse the negative number coordinates.  We fix it. Please refer to https://github.com/open-mmlab/mmtracking/blob/master/tools/convert_datasets/otb100/otb2coco.py#L87

Please use the new script to convert OTB100 dataset, if you used it before.