### PR TITLE
[Enhancement] Try to create a symbolic link on windows

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -160,5 +160,5 @@ To verify whether MMTracking and the required environment are installed correctl
 For example, run MOT demo and you will see a output video named `mot.mp4`:
 
 ```shell
-python demo/demo_mot_vis.py configs/mot/deepsort/sort_faster-rcnn_fpn_4e_mot17-private.py --input demo/demo.mp4 --output mot.mp4
+python demo/demo_mot.py configs/mot/deepsort/sort_faster-rcnn_fpn_4e_mot17-private.py --input demo/demo.mp4 --output mot.mp4
 ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -160,5 +160,5 @@ To verify whether MMTracking and the required environment are installed correctl
 For example, run MOT demo and you will see a output video named `mot.mp4`:
 
 ```shell
-python demo/demo_mot.py configs/mot/deepsort/sort_faster-rcnn_fpn_4e_mot17-private.py --input demo/demo.mp4 --output mot.mp4
+python demo/demo_mot_vis.py configs/mot/deepsort/sort_faster-rcnn_fpn_4e_mot17-private.py --input demo/demo.mp4 --output mot.mp4
 ```

--- a/setup.py
+++ b/setup.py
@@ -164,8 +164,20 @@ def add_mim_extension():
 
             if mode == 'symlink':
                 src_relpath = osp.relpath(src_path, osp.dirname(tar_path))
-                os.symlink(src_relpath, tar_path)
-            elif mode == 'copy':
+                try:
+                    os.symlink(src_relpath, tar_path)
+                except OSError:
+                    # Creating a symbolic link on windows may raise an
+                    # `OSError: [WinError 1314]` due to privilege. If
+                    # the error happens, the src file will be copied
+                    mode = 'copy'
+                    warnings.warn(
+                        f'Failed to create a symbolic link for {src_relpath}, '
+                        f'and it will be copied to {tar_path}')
+                else:
+                    continue
+
+            if mode == 'copy':
                 if osp.isfile(src_path):
                     shutil.copyfile(src_path, tar_path)
                 elif osp.isdir(src_path):


### PR DESCRIPTION
Related Issue: open-mmlab/mmdetection#6480

Creating a symbolic link on windows may raise an OSError: [WinError 1314] due to privilege. If the error happens, the src file will be copied.