### PR TITLE
Deprecate the support for "python setup.py test"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -213,8 +213,6 @@ if __name__ == '__main__':
             'Programming Language :: Python :: 3.9',
         ],
         license='Apache License 2.0',
-        setup_requires=parse_requirements('requirements/build.txt'),
-        tests_require=parse_requirements('requirements/tests.txt'),
         install_requires=parse_requirements('requirements/runtime.txt'),
         extras_require={
             'all': parse_requirements('requirements.txt'),


### PR DESCRIPTION
Reference: open-mmlab/mmcv#1637