### PR TITLE
[Fix] fix the dtype bug in ByteTracker

### DIFF
--- a/mmtrack/models/trackers/byte_tracker.py
+++ b/mmtrack/models/trackers/byte_tracker.py
@@ -185,7 +185,8 @@ class ByteTracker(BaseTracker):
 
         else:
             # 0. init
-            ids = torch.full((bboxes.size(0), ), -1).to(labels)
+            ids = torch.full((bboxes.size(0), ), -1,
+                             dtype=labels.dtype).to(labels)
 
             # get the detection bboxes for the first association
             first_det_inds = bboxes[:, -1] > self.obj_score_thrs['high']

--- a/mmtrack/models/trackers/byte_tracker.py
+++ b/mmtrack/models/trackers/byte_tracker.py
@@ -185,8 +185,10 @@ class ByteTracker(BaseTracker):
 
         else:
             # 0. init
-            ids = torch.full((bboxes.size(0), ), -1,
-                             dtype=labels.dtype).to(labels)
+            ids = torch.full((bboxes.size(0), ),
+                             -1,
+                             dtype=labels.dtype,
+                             device=labels.device)
 
             # get the detection bboxes for the first association
             first_det_inds = bboxes[:, -1] > self.obj_score_thrs['high']


### PR DESCRIPTION
Fix a bug in `torch_full()` where the `dtype` must be specified in pt1.6.