### PR TITLE
Update the installation of MMCV

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,10 +32,10 @@ jobs:
         torch: [1.5.1, 1.7.1]
         include:
           - torch: 1.5.1
-            torch_version: torch1.5.0
+            torch_version: torch1.5
             torchvision: 0.6.1
           - torch: 1.7.1
-            torch_version: torch1.7.0
+            torch_version: torch1.7
             torchvision: 0.8.2
     steps:
       - uses: actions/checkout@v2
@@ -73,10 +73,10 @@ jobs:
         torch: [1.5.1+cu101, 1.7.1+cu101]
         include:
           - torch: 1.5.1+cu101
-            torch_version: torch1.5.0
+            torch_version: torch1.5
             torchvision: 0.6.1+cu101
           - torch: 1.7.1+cu101
-            torch_version: torch1.7.0
+            torch_version: torch1.7
             torchvision: 0.8.2+cu101
 
     steps:
@@ -142,7 +142,7 @@ jobs:
         torch: [1.9.0+cu102]
         include:
           - torch: 1.9.0+cu102
-            torch_version: torch1.9.0
+            torch_version: torch1.9
             torchvision: 0.10.0+cu102
 
     steps:

--- a/docs/en/install.md
+++ b/docs/en/install.md
@@ -58,7 +58,15 @@ The compatible MMTracking, MMCV, and MMDetection versions are as below. Please i
 3. Install mmcv-full, we recommend you to install the pre-build package as below.
 
     ```shell
-    pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu101/torch1.6.0/index.html
+    # pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/{cu_version}/{torch_version}/index.html
+    pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu102/torch1.10.0/index.html
+    ```
+
+    mmcv-full is only compiled on PyTorch 1.x.0 because the compatibility usually holds between 1.x.0 and 1.x.1. If your PyTorch version is 1.x.1, you can install mmcv-full compiled with PyTorch 1.x.0 and it usually works well.
+
+    ```
+    # We can ignore the micro version of PyTorch
+    pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu102/torch1.10/index.html
     ```
 
     See [here](https://mmcv.readthedocs.io/en/latest/get_started/installation.html) for different versions of MMCV compatible to different PyTorch and CUDA versions.

--- a/docs/zh_cn/install.md
+++ b/docs/zh_cn/install.md
@@ -54,7 +54,15 @@
 3. 安装 mmcv-full，我们推荐您安装以下预构建包：
 
     ```shell
-    pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu101/torch1.6.0/index.html
+    # pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/{cu_version}/{torch_version}/index.html
+    pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu102/torch1.10.0/index.html
+    ```
+
+    PyTorch 在 1.x.0 和 1.x.1 之间通常是兼容的，故 mmcv-full 只提供 1.x.0 的编译包。如果你的 PyTorch 版本是 1.x.1，你可以放心地安装在 1.x.0 版本编译的 mmcv-full。
+
+    ```
+    # 我们可以忽略 PyTorch 的小版本号
+    pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu102/torch1.10/index.html
     ```
 
     请参阅 [MMCV](https://github.com/open-mmlab/mmcv#install-with-pip) 了解不同版本的 MMCV 与不同版本的 PyTorch 和 CUDA 的兼容情况。同时，您可以使用以下命令从源码编译 MMCV：


### PR DESCRIPTION
mmcv-full is only compiled on PyTorch 1.x.0 because the compatibility usually holds between 1.x.0 and 1.x.1. If your PyTorch version is 1.x.1, you can install mmcv-full compiled with PyTorch 1.x.0 and it usually works well.