### PR TITLE
[Enhancement] Speed up SOT test

### DIFF
--- a/mmtrack/datasets/base_sot_dataset.py
+++ b/mmtrack/datasets/base_sot_dataset.py
@@ -182,7 +182,7 @@ class BaseSOTDataset(Dataset, metaclass=ABCMeta):
         Returns:
             dict: testing data of one frame.
         """
-        if self.test_memo.get('video_ind', -1) != video_ind:
+        if self.test_memo.get('video_ind', None) != video_ind:
             self.test_memo.video_ind = video_ind
             self.test_memo.ann_infos = self.get_ann_infos_from_video(video_ind)
             self.test_memo.img_infos = self.get_img_infos_from_video(video_ind)

--- a/mmtrack/datasets/got10k_dataset.py
+++ b/mmtrack/datasets/got10k_dataset.py
@@ -114,11 +114,16 @@ class GOT10kDataset(BaseSOTDataset):
         Returns:
             dict: testing data of one frame.
         """
-        ann_infos = self.get_ann_infos_from_video(video_ind)
-        img_infos = self.get_img_infos_from_video(video_ind)
+        if self.test_memo.get('video_ind', -1) != video_ind:
+            self.test_memo.video_ind = video_ind
+            self.test_memo.img_infos = self.get_img_infos_from_video(video_ind)
+        assert 'video_ind' in self.test_memo and 'img_infos' in self.test_memo
+
         img_info = dict(
-            filename=img_infos['filename'][frame_ind], frame_id=frame_ind)
+            filename=self.test_memo.img_infos['filename'][frame_ind],
+            frame_id=frame_ind)
         if frame_ind == 0:
+            ann_infos = self.get_ann_infos_from_video(video_ind)
             ann_info = dict(
                 bboxes=ann_infos['bboxes'][frame_ind], visible=True)
         else:

--- a/mmtrack/datasets/got10k_dataset.py
+++ b/mmtrack/datasets/got10k_dataset.py
@@ -114,7 +114,7 @@ class GOT10kDataset(BaseSOTDataset):
         Returns:
             dict: testing data of one frame.
         """
-        if self.test_memo.get('video_ind', -1) != video_ind:
+        if self.test_memo.get('video_ind', None) != video_ind:
             self.test_memo.video_ind = video_ind
             self.test_memo.img_infos = self.get_img_infos_from_video(video_ind)
         assert 'video_ind' in self.test_memo and 'img_infos' in self.test_memo

--- a/mmtrack/datasets/trackingnet_dataset.py
+++ b/mmtrack/datasets/trackingnet_dataset.py
@@ -106,7 +106,7 @@ class TrackingNetDataset(BaseSOTDataset):
         Returns:
             dict: testing data of one frame.
         """
-        if self.test_memo.get('video_ind', -1) != video_ind:
+        if self.test_memo.get('video_ind', None) != video_ind:
             self.test_memo.video_ind = video_ind
             self.test_memo.img_infos = self.get_img_infos_from_video(video_ind)
         assert 'video_ind' in self.test_memo and 'img_infos' in self.test_memo

--- a/mmtrack/datasets/trackingnet_dataset.py
+++ b/mmtrack/datasets/trackingnet_dataset.py
@@ -106,11 +106,16 @@ class TrackingNetDataset(BaseSOTDataset):
         Returns:
             dict: testing data of one frame.
         """
-        ann_infos = self.get_ann_infos_from_video(video_ind)
-        img_infos = self.get_img_infos_from_video(video_ind)
+        if self.test_memo.get('video_ind', -1) != video_ind:
+            self.test_memo.video_ind = video_ind
+            self.test_memo.img_infos = self.get_img_infos_from_video(video_ind)
+        assert 'video_ind' in self.test_memo and 'img_infos' in self.test_memo
+
         img_info = dict(
-            filename=img_infos['filename'][frame_ind], frame_id=frame_ind)
+            filename=self.test_memo.img_infos['filename'][frame_ind],
+            frame_id=frame_ind)
         if frame_ind == 0:
+            ann_infos = self.get_ann_infos_from_video(video_ind)
             ann_info = dict(
                 bboxes=ann_infos['bboxes'][frame_ind], visible=True)
         else:


### PR DESCRIPTION
We speed up SOT test by avoiding reloading the files of video information repeatedly in all frames of one video.