### PR TITLE
[Fix] Fix an important bug about loading lasot dataset

### DIFF
--- a/mmtrack/datasets/lasot_dataset.py
+++ b/mmtrack/datasets/lasot_dataset.py
@@ -54,7 +54,7 @@ class LaSOTDataset(BaseSOTDataset):
         if self.test_mode:
             videos_list = test_videos_list.tolist()
         else:
-            all_videos_list = glob.glob(self.img_prefix + '/*/*-[1-20]')
+            all_videos_list = glob.glob(self.img_prefix + '/*/*-*')
             test_videos = set(test_videos_list)
             videos_list = []
             for x in all_videos_list:


### PR DESCRIPTION
The original search implements about `glob.glob(self.img_prefix + '/*/*-[1-20]')` can  only find  the videos whose name end with 1 and 2, not  from 1 to 20.

This PR is an urgent bug fix. 

The subsequent refactor of parsing SOT dataset will also fix this bug, and we will also retrain the STARK model on the joint datasets.