### PR TITLE
[Fix] Change the type of `label` from `int32` to `int64` in the args of `F.cross_entropy` for pytorch 1.11

### DIFF
--- a/mmtrack/models/track_heads/roi_embed_head.py
+++ b/mmtrack/models/track_heads/roi_embed_head.py
@@ -216,7 +216,7 @@ class RoIEmbedHead(BaseModule):
                 if id in ref_gt_instance_id:
                     pos_match_id[i] = ref_gt_instance_id.tolist().index(id) + 1
 
-            track_id_target = gt_instance_id.new_zeros(len(res.bboxes))
+            track_id_target = gt_instance_id.new_zeros(len(res.bboxes), dtype=torch.int64)
             track_id_target[:len(res.pos_bboxes)] = pos_match_id
             track_id_weight = res.bboxes.new_zeros(len(res.bboxes))
             track_id_weight[:len(res.pos_bboxes)] = 1.0

--- a/mmtrack/models/track_heads/roi_embed_head.py
+++ b/mmtrack/models/track_heads/roi_embed_head.py
@@ -216,7 +216,8 @@ class RoIEmbedHead(BaseModule):
                 if id in ref_gt_instance_id:
                     pos_match_id[i] = ref_gt_instance_id.tolist().index(id) + 1
 
-            track_id_target = gt_instance_id.new_zeros(len(res.bboxes), dtype=torch.int64)
+            track_id_target = gt_instance_id.new_zeros(
+                len(res.bboxes), dtype=torch.int64)
             track_id_target[:len(res.pos_bboxes)] = pos_match_id
             track_id_weight = res.bboxes.new_zeros(len(res.bboxes))
             track_id_weight[:len(res.pos_bboxes)] = 1.0


### PR DESCRIPTION
**Bug Fixes**
In Pytorch 1.11, `F.cross_entropy` only allows the labels with the type of `int64` rather than `int32`. We fix the bug in the `get_target()` function of `roi_embed_head.py`.