### PR TITLE
[Doc] link development roadmap in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ Documentation: https://mmtracking.readthedocs.io/
 
 ## Introduction
 
-MMTracking is an open source video perception toolbox based on PyTorch.
-It is a part of the OpenMMLab project.
+MMTracking is an open source video perception toolbox by PyTorch. It is a part of [OpenMMLab](https://openmmlab.com) project.
 
 The master branch works with **PyTorch1.5+**.
 
@@ -109,7 +108,7 @@ There are also usage [tutorials](docs/en/tutorials/), such as [learning about co
 
 ## Contributing
 
-We appreciate all contributions to improve MMTracking. Please refer to [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) for the contributing guideline.
+We appreciate all contributions to improve MMTracking. Please refer to [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) for the guidelines and [this discussion](https://github.com/open-mmlab/mmtracking/issues/73) for development roadmap.
 
 ## Acknowledgement
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -105,7 +105,7 @@ MMTracking也提供了更详细的[教程](docs/en/tutorials/)，比如[配置�
 
 ## 参与贡献
 
-我们非常欢迎用户对于MMTracking做出的任何贡献，可以参考[贡献指南](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md)文件了解更多细节。
+我们非常欢迎用户对于MMTracking做出的任何贡献，可以参考[贡献指南](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md)文件了解更多细节和在这个[讨论](https://github.com/open-mmlab/mmtracking/issues/73)中规划MMTracking的开发计划。
 
 ## 致谢
 


### PR DESCRIPTION
It should be helpful to gain more attention of potential users and contributors by emphasizing the development roadmap in README.