### PR TITLE
[Doc] Edit benchmark gallery in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Please refer to [changelog.md](docs/en/changelog.md) for details and release his
 
 ## Benchmark and model zoo
 
-Results and models are available in the [model zoo](docs/en/model_zoo.md). The supported and on-the-way methods and datasets are listed below.
+Results and models are available in the [model zoo](docs/en/model_zoo.md). The supported (:white_check_mark:) and on-the-way (:o:) methods and datasets are listed below.
 
 <style>
 td, th {

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ There are also usage [tutorials](docs/en/tutorials/), such as [learning about co
 
 ## Contributing
 
-We appreciate all contributions to improve MMTracking. Please refer to [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) for the contributing guideline.
+We appreciate all contributions to improve MMTracking. Please refer to [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) for the contributing guideline and [this discussion](https://github.com/open-mmlab/mmtracking/issues/73) for development roadmap.
 
 ## Acknowledgement
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ Documentation: https://mmtracking.readthedocs.io/
 
 ## Introduction
 
-MMTracking is an open source video perception toolbox based on PyTorch.
-It is a part of the OpenMMLab project.
+MMTracking is an open source video perception toolbox based on PyTorch. It is a part of [OpenMMLab]((https://openmmlab.com)) project.
 
 The master branch works with **PyTorch1.5+**.
 
@@ -74,12 +73,6 @@ Please refer to [changelog.md](docs/en/changelog.md) for details and release his
 
 Results and models are available in the [model zoo](docs/en/model_zoo.md). The supported (:white_check_mark:) and on-the-way (:o:) methods and datasets are listed below.
 
-<style>
-td, th {
-   border: none!important;
-}
-</style>
-
 ### Video Object Detection
 
 | Method                                                                              | Dataset                                                                  |
@@ -108,15 +101,15 @@ td, th {
 | :white_check_mark:  [Tracktor](configs/mot/tracktor) (ICCV 2019)           | :white_check_mark:    [CrowdHuman](https://www.crowdhuman.org/) |
 | :white_check_mark:  [QDTrack](configs/mot/qdtrack) (CVPR 2021)             | :white_check_mark:   [LVIS](https://www.lvisdataset.org/)       |
 | :white_check_mark:  [ByteTrack](configs/mot/bytetrack) (arXiv 2021)        | :white_check_mark:   [TAO](https://taodataset.org/)             |
-| :o: [OC-SORT](https://github.com/noahcao/OC_SORT)  (arXiv 2022)            | :o: [DanceTrack](https://dancetrack.github.io)                  |
-| :o: [CenterTrack](https://github.com/xingyizhou/CenterTrack) (ECCV 2020)   | :o:  [BDD100k](https://www.bdd100k.com)                         |
+| :o: [OC-SORT](https://arxiv.org/abs/2203.14360)  (arXiv 2022)              | :o: [DanceTrack](https://arxiv.org/abs/2111.14690)              |
+| :o: [CenterTrack](https://arxiv.org/abs/2004.01177) (ECCV 2020)            | :o:  [BDD100k](https://arxiv.org/abs/1805.04687)                |
 
 ### Video Instance Segmentation
 
 | Method                                                                         | Dataset                                                                 |
 | ------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
 | :white_check_mark: [MaskTrack R-CNN](configs/vis/masktrack_rcnn) (ICCV 2019)   | :white_check_mark:  [YouTube-VIS](https://youtube-vos.org/dataset/vis/) |
-| :o: [Mask2Former](https://github.com/facebookresearch/Mask2Former) (CVPR 2022) | :o: [OVIS](http://songbai.site/ovis)                                    |
+| :o: [Mask2Former](https://github.com/facebookresearch/Mask2Former) (CVPR 2022) | :o: [OVIS](https://arxiv.org/abs/2102.01558)                            |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Documentation: https://mmtracking.readthedocs.io/
 
 ## Introduction
 
-MMTracking is an open source video perception toolbox based on PyTorch. It is a part of [OpenMMLab]((https://openmmlab.com)) project.
+MMTracking is an open source video perception toolbox by PyTorch. It is a part of [OpenMMLab](https://openmmlab.com) project.
 
 The master branch works with **PyTorch1.5+**.
 
@@ -78,9 +78,9 @@ Results and models are available in the [model zoo](docs/en/model_zoo.md).
 Supported Methods
 
 - [x] [DFF](configs/vid/dff) (CVPR 2017)
-- [ ] [FGFA](configs/vid/fgfa) (ICCV 2017)
-- [ ] [SELSA](configs/vid/selsa) (ICCV 2019)
-- [ ] [Temporal RoI Align](configs/vid/temporal_roi_align) (AAAI 2021)
+- [x] [FGFA](configs/vid/fgfa) (ICCV 2017)
+- [x] [SELSA](configs/vid/selsa) (ICCV 2019)
+- [x] [Temporal RoI Align](configs/vid/temporal_roi_align) (AAAI 2021)
 
 Supported Datasets
 
@@ -108,7 +108,6 @@ Supported Methods
 
 - [x] [SORT/DeepSORT](configs/mot/deepsort) (ICIP 2016/2017)
 - [x] [Tracktor](configs/mot/tracktor) (ICCV 2019)
-- [ ] [CenterTrack](https://arxiv.org/abs/2004.01177) (ECCV 2020)
 - [x] [QDTrack](configs/mot/qdtrack) (CVPR 2021)
 - [x] [ByteTrack](configs/mot/bytetrack) (arXiv 2021)
 - [ ] [OC-SORT](https://arxiv.org/abs/2203.14360)  (arXiv 2022)
@@ -120,19 +119,16 @@ Supported Datasets
 - [x] [LVIS](https://www.lvisdataset.org/)
 - [x] [TAO](https://taodataset.org/)
 - [ ] [DanceTrack](https://arxiv.org/abs/2111.14690)
-- [ ] [BDD100k](https://arxiv.org/abs/1805.04687)
 
 ### Video Instance Segmentation
 
 Supported Methods
 
 - [x] [MaskTrack R-CNN](configs/vis/masktrack_rcnn) (ICCV 2019)
-- [ ] [Mask2Former](https://github.com/facebookresearch/Mask2Former) (CVPR 2022)
 
 Supported Datasets
 
 - [x] [YouTube-VIS](https://youtube-vos.org/dataset/vis/)
-- [ ] [OVIS](https://arxiv.org/abs/2102.01558)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -71,45 +71,68 @@ Please refer to [changelog.md](docs/en/changelog.md) for details and release his
 
 ## Benchmark and model zoo
 
-Results and models are available in the [model zoo](docs/en/model_zoo.md). The supported (:white_check_mark:) and on-the-way (:o:) methods and datasets are listed below.
+Results and models are available in the [model zoo](docs/en/model_zoo.md).
 
 ### Video Object Detection
 
-| Method                                                                              | Dataset                                                                  |
-| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| :white_check_mark:  [DFF](configs/vid/dff) (CVPR 2017)                              | :white_check_mark: [ILSVRC](http://image-net.org/challenges/LSVRC/2017/) |
-| :white_check_mark: [FGFA](configs/vid/fgfa) (ICCV 2017)                             |                                                                          |
-| :white_check_mark: [SELSA](configs/vid/selsa) (ICCV 2019)                           |                                                                          |
-| :white_check_mark: [Temporal RoI Align](configs/vid/temporal_roi_align) (AAAI 2021) |                                                                          |
+Supported Methods
+
+- [x] [DFF](configs/vid/dff) (CVPR 2017)
+- [ ] [FGFA](configs/vid/fgfa) (ICCV 2017)
+- [ ] [SELSA](configs/vid/selsa) (ICCV 2019)
+- [ ] [Temporal RoI Align](configs/vid/temporal_roi_align) (AAAI 2021)
+
+Supported Datasets
+
+- [x] [ILSVRC](http://image-net.org/challenges/LSVRC/2017/)
 
 ### Single Object Tracking
 
-| Method                                                                 | Dataset                                                                 |
-| ---------------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| :white_check_mark: [SiameseRPN++](configs/sot/siamese_rpn) (CVPR 2019) | :white_check_mark:    [LaSOT](http://vision.cs.stonybrook.edu/~lasot/)  |
-| :white_check_mark: [STARK](configs/sot/stark) (ICCV 2021)              | :white_check_mark:    [UAV123](https://cemse.kaust.edu.sa/ivul/uav123/) |
-|                                                                        | :white_check_mark:  [TrackingNet](https://tracking-net.org/)            |
-|                                                                        | :white_check_mark:  [OTB100](http://www.visual-tracking.net/)           |
-|                                                                        | :white_check_mark:  [GOT10k](http://got-10k.aitestunion.com/)           |
-|                                                                        | :white_check_mark:  [VOT2018](https://www.votchallenge.net/vot2018/)    |
+Supported Methods
+
+- [x] [SiameseRPN++](configs/sot/siamese_rpn) (CVPR 2019)
+- [x] [STARK](configs/sot/stark) (ICCV 2021)
+
+Supported Datasets
+
+- [x] [LaSOT](http://vision.cs.stonybrook.edu/~lasot/)
+- [x] [UAV123](https://cemse.kaust.edu.sa/ivul/uav123/)
+- [x] [TrackingNet](https://tracking-net.org/)
+- [x] [OTB100](http://www.visual-tracking.net/)
+- [x] [GOT10k](http://got-10k.aitestunion.com/)
+- [x] [VOT2018](https://www.votchallenge.net/vot2018/)
 
 ### Multi-Object Tracking
 
-| Method                                                                     | Dataset                                                         |
-| -------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| :white_check_mark:  [SORT/DeepSORT](configs/mot/deepsort) (ICIP 2016/2017) | :white_check_mark:  [MOT Challenge](https://motchallenge.net/)  |
-| :white_check_mark:  [Tracktor](configs/mot/tracktor) (ICCV 2019)           | :white_check_mark:    [CrowdHuman](https://www.crowdhuman.org/) |
-| :white_check_mark:  [QDTrack](configs/mot/qdtrack) (CVPR 2021)             | :white_check_mark:   [LVIS](https://www.lvisdataset.org/)       |
-| :white_check_mark:  [ByteTrack](configs/mot/bytetrack) (arXiv 2021)        | :white_check_mark:   [TAO](https://taodataset.org/)             |
-| :o: [OC-SORT](https://arxiv.org/abs/2203.14360)  (arXiv 2022)              | :o: [DanceTrack](https://arxiv.org/abs/2111.14690)              |
-| :o: [CenterTrack](https://arxiv.org/abs/2004.01177) (ECCV 2020)            | :o:  [BDD100k](https://arxiv.org/abs/1805.04687)                |
+Supported Methods
+
+- [x] [SORT/DeepSORT](configs/mot/deepsort) (ICIP 2016/2017)
+- [x] [Tracktor](configs/mot/tracktor) (ICCV 2019)
+- [ ] [CenterTrack](https://arxiv.org/abs/2004.01177) (ECCV 2020)
+- [x] [QDTrack](configs/mot/qdtrack) (CVPR 2021)
+- [x] [ByteTrack](configs/mot/bytetrack) (arXiv 2021)
+- [ ] [OC-SORT](https://arxiv.org/abs/2203.14360)  (arXiv 2022)
+
+Supported Datasets
+
+- [x] [MOT Challenge](https://motchallenge.net/)
+- [x] [CrowdHuman](https://www.crowdhuman.org/)
+- [x] [LVIS](https://www.lvisdataset.org/)
+- [x] [TAO](https://taodataset.org/)
+- [ ] [DanceTrack](https://arxiv.org/abs/2111.14690)
+- [ ] [BDD100k](https://arxiv.org/abs/1805.04687)
 
 ### Video Instance Segmentation
 
-| Method                                                                         | Dataset                                                                 |
-| ------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
-| :white_check_mark: [MaskTrack R-CNN](configs/vis/masktrack_rcnn) (ICCV 2019)   | :white_check_mark:  [YouTube-VIS](https://youtube-vos.org/dataset/vis/) |
-| :o: [Mask2Former](https://github.com/facebookresearch/Mask2Former) (CVPR 2022) | :o: [OVIS](https://arxiv.org/abs/2102.01558)                            |
+Supported Methods
+
+- [x] [MaskTrack R-CNN](configs/vis/masktrack_rcnn) (ICCV 2019)
+- [ ] [Mask2Former](https://github.com/facebookresearch/Mask2Former) (CVPR 2022)
+
+Supported Datasets
+
+- [x] [YouTube-VIS](https://youtube-vos.org/dataset/vis/)
+- [ ] [OVIS](https://arxiv.org/abs/2102.01558)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Documentation: https://mmtracking.readthedocs.io/
 
 ## Introduction
 
-MMTracking is an open source video perception toolbox by PyTorch. It is a part of [OpenMMLab](https://openmmlab.com) project.
+MMTracking is an open source video perception toolbox based on PyTorch.
+It is a part of the OpenMMLab project.
 
 The master branch works with **PyTorch1.5+**.
 
@@ -71,30 +72,51 @@ Please refer to [changelog.md](docs/en/changelog.md) for details and release his
 
 ## Benchmark and model zoo
 
-Results and models are available in the [model zoo](docs/en/model_zoo.md).
+Results and models are available in the [model zoo](docs/en/model_zoo.md). The supported and on-the-way methods and datasets are listed below.
 
-Supported methods of video object detection:
+<style>
+td, th {
+   border: none!important;
+}
+</style>
 
-- [x] [DFF](configs/vid/dff) (CVPR 2017)
-- [x] [FGFA](configs/vid/fgfa) (ICCV 2017)
-- [x] [SELSA](configs/vid/selsa) (ICCV 2019)
-- [x] [Temporal RoI Align](configs/vid/temporal_roi_align) (AAAI 2021)
+### Video Object Detection
 
-Supported methods of multi object tracking:
+| <div style="width:290px">Method</div>                                                               | <div style="width:290px">Dataset</div>                                                   |
+| --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| <input type="checkbox"  checked />  [DFF](configs/vid/dff) (CVPR 2017)                              | <input type="checkbox"  checked /> [ILSVRC](http://image-net.org/challenges/LSVRC/2017/) |
+| <input type="checkbox"  checked /> [FGFA](configs/vid/fgfa) (ICCV 2017)                             |                                                                                          |
+| <input type="checkbox"  checked /> [SELSA](configs/vid/selsa) (ICCV 2019)                           |                                                                                          |
+| <input type="checkbox"  checked /> [Temporal RoI Align](configs/vid/temporal_roi_align) (AAAI 2021) |                                                                                          |
 
-- [x] [SORT/DeepSORT](configs/mot/deepsort) (ICIP 2016/2017)
-- [x] [Tracktor](configs/mot/tracktor) (ICCV 2019)
-- [x] [QDTrack](configs/mot/qdtrack) (CVPR 2021)
-- [x] [ByteTrack](configs/mot/bytetrack) (arXiv 2021)
+### Single Object Tracking
 
-Supported methods of single object tracking:
+| <div style="width:290px">Method</div>                                                  | <div style="width:290px">Dataset</div>                                                  |
+| -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| <input type="checkbox"  checked /> [SiameseRPN++](configs/sot/siamese_rpn) (CVPR 2019) | <input type="checkbox"  checked />    [LaSOT](http://vision.cs.stonybrook.edu/~lasot/)  |
+| <input type="checkbox"  checked /> [STARK](configs/sot/stark) (ICCV 2021)              | <input type="checkbox"  checked />    [UAV123](https://cemse.kaust.edu.sa/ivul/uav123/) |
+|                                                                                        | <input type="checkbox"  checked />  [TrackingNet](https://tracking-net.org/)            |
+|                                                                                        | <input type="checkbox"  checked />  [OTB100](http://www.visual-tracking.net/)           |
+|                                                                                        | <input type="checkbox"  checked />  [GOT10k](http://got-10k.aitestunion.com/)           |
+|                                                                                        | <input type="checkbox"  checked />  [VOT2018](https://www.votchallenge.net/vot2018/)    |
 
-- [x] [SiameseRPN++](configs/sot/siamese_rpn) (CVPR 2019)
-- [x] [STARK](configs/sot/stark) (ICCV 2021)
+### Multi-Object Tracking
 
-Supported methods of video instance segmentation:
+| <div style="width:290px">Method</div>                                                          | <div style="width:290px">Dataset</div>                                          |
+| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| <input type="checkbox"  checked />  [SORT/DeepSORT](configs/mot/deepsort) (ICIP 2016/2017)     | <input type="checkbox" checked />  [MOT Challenge](https://motchallenge.net/)   |
+| <input type="checkbox"  checked />  [Tracktor](configs/mot/tracktor) (ICCV 2019)               | <input type="checkbox"  checked />    [CrowdHuman](https://www.crowdhuman.org/) |
+| <input type="checkbox"  checked />  [QDTrack](configs/mot/qdtrack) (CVPR 2021)                 | <input type="checkbox"  checked />   [LVIS](https://www.lvisdataset.org/)       |
+| <input type="checkbox"  checked />  [ByteTrack](configs/mot/bytetrack) (arXiv 2021)            | <input type="checkbox"  checked />   [TAO](https://taodataset.org/)             |
+| <input type="checkbox" /> [OC-SORT](https://github.com/noahcao/OC_SORT)  (arXiv 2022)          | <input type="checkbox" /> [DanceTrack](https://dancetrack.github.io)            |
+| <input type="checkbox" /> [CenterTrack](https://github.com/xingyizhou/CenterTrack) (ECCV 2020) | <input type="checkbox" />  [BDD100k](https://www.bdd100k.com)                   |
 
-- [x] [MaskTrack R-CNN](configs/vis/masktrack_rcnn) (ICCV 2019)
+### Video Instance Segmentation
+
+| <div style="width:290px">Method</div>                                                               | <div style="width:290px">Dataset</div>                                                  |
+| --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| <input type="checkbox"  checked /> [MaskTrack R-CNN](configs/vis/masktrack_rcnn) (ICCV 2019)        | <input type="checkbox"  checked />  [YouTube-VIS](https://youtube-vos.org/dataset/vis/) |
+| <input type="checkbox" > [Mask2Former](https://github.com/facebookresearch/Mask2Former) (CVPR 2022) | <input type="checkbox" > [OVIS](http://songbai.site/ovis)                               |
 
 ## Installation
 
@@ -108,7 +130,7 @@ There are also usage [tutorials](docs/en/tutorials/), such as [learning about co
 
 ## Contributing
 
-We appreciate all contributions to improve MMTracking. Please refer to [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) for the guidelines and [this discussion](https://github.com/open-mmlab/mmtracking/issues/73) for development roadmap.
+We appreciate all contributions to improve MMTracking. Please refer to [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) for the contributing guideline.
 
 ## Acknowledgement
 

--- a/README.md
+++ b/README.md
@@ -82,41 +82,41 @@ td, th {
 
 ### Video Object Detection
 
-| <div style="width:290px">Method</div>                                                               | <div style="width:290px">Dataset</div>                                                   |
-| --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| <input type="checkbox"  checked />  [DFF](configs/vid/dff) (CVPR 2017)                              | <input type="checkbox"  checked /> [ILSVRC](http://image-net.org/challenges/LSVRC/2017/) |
-| <input type="checkbox"  checked /> [FGFA](configs/vid/fgfa) (ICCV 2017)                             |                                                                                          |
-| <input type="checkbox"  checked /> [SELSA](configs/vid/selsa) (ICCV 2019)                           |                                                                                          |
-| <input type="checkbox"  checked /> [Temporal RoI Align](configs/vid/temporal_roi_align) (AAAI 2021) |                                                                                          |
+| Method                                                                              | Dataset                                                                  |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| :white_check_mark:  [DFF](configs/vid/dff) (CVPR 2017)                              | :white_check_mark: [ILSVRC](http://image-net.org/challenges/LSVRC/2017/) |
+| :white_check_mark: [FGFA](configs/vid/fgfa) (ICCV 2017)                             |                                                                          |
+| :white_check_mark: [SELSA](configs/vid/selsa) (ICCV 2019)                           |                                                                          |
+| :white_check_mark: [Temporal RoI Align](configs/vid/temporal_roi_align) (AAAI 2021) |                                                                          |
 
 ### Single Object Tracking
 
-| <div style="width:290px">Method</div>                                                  | <div style="width:290px">Dataset</div>                                                  |
-| -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| <input type="checkbox"  checked /> [SiameseRPN++](configs/sot/siamese_rpn) (CVPR 2019) | <input type="checkbox"  checked />    [LaSOT](http://vision.cs.stonybrook.edu/~lasot/)  |
-| <input type="checkbox"  checked /> [STARK](configs/sot/stark) (ICCV 2021)              | <input type="checkbox"  checked />    [UAV123](https://cemse.kaust.edu.sa/ivul/uav123/) |
-|                                                                                        | <input type="checkbox"  checked />  [TrackingNet](https://tracking-net.org/)            |
-|                                                                                        | <input type="checkbox"  checked />  [OTB100](http://www.visual-tracking.net/)           |
-|                                                                                        | <input type="checkbox"  checked />  [GOT10k](http://got-10k.aitestunion.com/)           |
-|                                                                                        | <input type="checkbox"  checked />  [VOT2018](https://www.votchallenge.net/vot2018/)    |
+| Method                                                                 | Dataset                                                                 |
+| ---------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| :white_check_mark: [SiameseRPN++](configs/sot/siamese_rpn) (CVPR 2019) | :white_check_mark:    [LaSOT](http://vision.cs.stonybrook.edu/~lasot/)  |
+| :white_check_mark: [STARK](configs/sot/stark) (ICCV 2021)              | :white_check_mark:    [UAV123](https://cemse.kaust.edu.sa/ivul/uav123/) |
+|                                                                        | :white_check_mark:  [TrackingNet](https://tracking-net.org/)            |
+|                                                                        | :white_check_mark:  [OTB100](http://www.visual-tracking.net/)           |
+|                                                                        | :white_check_mark:  [GOT10k](http://got-10k.aitestunion.com/)           |
+|                                                                        | :white_check_mark:  [VOT2018](https://www.votchallenge.net/vot2018/)    |
 
 ### Multi-Object Tracking
 
-| <div style="width:290px">Method</div>                                                          | <div style="width:290px">Dataset</div>                                          |
-| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| <input type="checkbox"  checked />  [SORT/DeepSORT](configs/mot/deepsort) (ICIP 2016/2017)     | <input type="checkbox" checked />  [MOT Challenge](https://motchallenge.net/)   |
-| <input type="checkbox"  checked />  [Tracktor](configs/mot/tracktor) (ICCV 2019)               | <input type="checkbox"  checked />    [CrowdHuman](https://www.crowdhuman.org/) |
-| <input type="checkbox"  checked />  [QDTrack](configs/mot/qdtrack) (CVPR 2021)                 | <input type="checkbox"  checked />   [LVIS](https://www.lvisdataset.org/)       |
-| <input type="checkbox"  checked />  [ByteTrack](configs/mot/bytetrack) (arXiv 2021)            | <input type="checkbox"  checked />   [TAO](https://taodataset.org/)             |
-| <input type="checkbox" /> [OC-SORT](https://github.com/noahcao/OC_SORT)  (arXiv 2022)          | <input type="checkbox" /> [DanceTrack](https://dancetrack.github.io)            |
-| <input type="checkbox" /> [CenterTrack](https://github.com/xingyizhou/CenterTrack) (ECCV 2020) | <input type="checkbox" />  [BDD100k](https://www.bdd100k.com)                   |
+| Method                                                                     | Dataset                                                         |
+| -------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| :white_check_mark:  [SORT/DeepSORT](configs/mot/deepsort) (ICIP 2016/2017) | :white_check_mark:  [MOT Challenge](https://motchallenge.net/)  |
+| :white_check_mark:  [Tracktor](configs/mot/tracktor) (ICCV 2019)           | :white_check_mark:    [CrowdHuman](https://www.crowdhuman.org/) |
+| :white_check_mark:  [QDTrack](configs/mot/qdtrack) (CVPR 2021)             | :white_check_mark:   [LVIS](https://www.lvisdataset.org/)       |
+| :white_check_mark:  [ByteTrack](configs/mot/bytetrack) (arXiv 2021)        | :white_check_mark:   [TAO](https://taodataset.org/)             |
+| :o: [OC-SORT](https://github.com/noahcao/OC_SORT)  (arXiv 2022)            | :o: [DanceTrack](https://dancetrack.github.io)                  |
+| :o: [CenterTrack](https://github.com/xingyizhou/CenterTrack) (ECCV 2020)   | :o:  [BDD100k](https://www.bdd100k.com)                         |
 
 ### Video Instance Segmentation
 
-| <div style="width:290px">Method</div>                                                               | <div style="width:290px">Dataset</div>                                                  |
-| --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| <input type="checkbox"  checked /> [MaskTrack R-CNN](configs/vis/masktrack_rcnn) (ICCV 2019)        | <input type="checkbox"  checked />  [YouTube-VIS](https://youtube-vos.org/dataset/vis/) |
-| <input type="checkbox" > [Mask2Former](https://github.com/facebookresearch/Mask2Former) (CVPR 2022) | <input type="checkbox" > [OVIS](http://songbai.site/ovis)                               |
+| Method                                                                         | Dataset                                                                 |
+| ------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
+| :white_check_mark: [MaskTrack R-CNN](configs/vis/masktrack_rcnn) (ICCV 2019)   | :white_check_mark:  [YouTube-VIS](https://youtube-vos.org/dataset/vis/) |
+| :o: [Mask2Former](https://github.com/facebookresearch/Mask2Former) (CVPR 2022) | :o: [OVIS](http://songbai.site/ovis)                                    |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Supported Methods
 
 - [x] [SiameseRPN++](configs/sot/siamese_rpn) (CVPR 2019)
 - [x] [STARK](configs/sot/stark) (ICCV 2021)
+- [ ] [PrDiMP](https://arxiv.org/abs/2003.12565) (CVPR2020)
 
 Supported Datasets
 
@@ -118,7 +119,7 @@ Supported Datasets
 - [x] [CrowdHuman](https://www.crowdhuman.org/)
 - [x] [LVIS](https://www.lvisdataset.org/)
 - [x] [TAO](https://taodataset.org/)
-- [ ] [DanceTrack](https://arxiv.org/abs/2111.14690)
+- [x] [DanceTrack](https://arxiv.org/abs/2111.14690)
 
 ### Video Instance Segmentation
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Supported Methods
 
 - [x] [SiameseRPN++](configs/sot/siamese_rpn) (CVPR 2019)
 - [x] [STARK](configs/sot/stark) (ICCV 2021)
-- [ ] [PrDiMP](https://arxiv.org/abs/2003.12565) (CVPR2020)
+- [ ] [PrDiMP](https://arxiv.org/abs/2003.12565) (CVPR2020) (WIP)
 
 Supported Datasets
 
@@ -111,7 +111,7 @@ Supported Methods
 - [x] [Tracktor](configs/mot/tracktor) (ICCV 2019)
 - [x] [QDTrack](configs/mot/qdtrack) (CVPR 2021)
 - [x] [ByteTrack](configs/mot/bytetrack) (arXiv 2021)
-- [ ] [OC-SORT](https://arxiv.org/abs/2203.14360)  (arXiv 2022)
+- [ ] [OC-SORT](https://arxiv.org/abs/2203.14360)  (arXiv 2022) (WIP)
 
 Supported Datasets
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -72,14 +72,14 @@ v0.13.0版本已于2022年04月29日发布，可通过查阅[更新日志](docs/
 
 ### 视频目标检测
 
-支持的视频目标检测算法:
+支持的算法:
 
 - [x] [DFF](configs/vid/dff) (CVPR 2017)
 - [x] [FGFA](configs/vid/fgfa) (ICCV 2017)
 - [x] [SELSA](configs/vid/selsa) (ICCV 2019)
 - [x] [Temporal RoI Align](configs/vid/temporal_roi_align) (AAAI 2021)
 
-支持的视频目标检测数据集：
+支持的数据集：
 
 - [x] [ILSVRC](http://image-net.org/challenges/LSVRC/2017/)
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -70,6 +70,8 @@ v0.13.0版本已于2022年04月29日发布，可通过查阅[更新日志](docs/
 
 本工具箱支持的各个模型的结果和设置都可以在[模型库](docs/en/model_zoo.md)页面中查看。
 
+### 视频目标检测
+
 支持的视频目标检测算法:
 
 - [x] [DFF](configs/vid/dff) (CVPR 2017)
@@ -77,21 +79,57 @@ v0.13.0版本已于2022年04月29日发布，可通过查阅[更新日志](docs/
 - [x] [SELSA](configs/vid/selsa) (ICCV 2019)
 - [x] [Temporal RoI Align](configs/vid/temporal_roi_align) (AAAI 2021)
 
-支持的多目标跟踪算法:
+支持的视频目标检测数据集：
 
-- [x] [SORT/DeepSORT](configs/mot/deepsort) (ICIP 2016/2017)
-- [x] [Tracktor](configs/mot/tracktor) (ICCV 2019)
-- [x] [QDTrack](configs/mot/qdtrack) (CVPR 2021)
-- [x] [ByteTrack](configs/mot/bytetrack) (arXiv 2021)
+- [x] [ILSVRC](http://image-net.org/challenges/LSVRC/2017/)
 
-支持的单目标跟踪算法:
+### 单目标跟踪
+
+支持的算法:
 
 - [x] [SiameseRPN++](configs/sot/siamese_rpn) (CVPR 2019)
 - [x] [STARK](configs/sot/stark) (ICCV 2021)
 
-支持的视频实例分割算法:
+支持的数据集：
+
+- [x] [LaSOT](http://vision.cs.stonybrook.edu/~lasot/)
+- [x] [UAV123](https://cemse.kaust.edu.sa/ivul/uav123/)
+- [x] [TrackingNet](https://tracking-net.org/)
+- [x] [OTB100](http://www.visual-tracking.net/)
+- [x] [GOT10k](http://got-10k.aitestunion.com/)
+- [x] [VOT2018](https://www.votchallenge.net/vot2018/)
+
+### 多目标跟踪
+
+支持的算法:
+
+- [x] [SORT/DeepSORT](configs/mot/deepsort) (ICIP 2016/2017)
+- [x] [Tracktor](configs/mot/tracktor) (ICCV 2019)
+- [ ] [CenterTrack](https://arxiv.org/abs/2004.01177) (ECCV 2020)
+- [x] [QDTrack](configs/mot/qdtrack) (CVPR 2021)
+- [x] [ByteTrack](configs/mot/bytetrack) (arXiv 2021)
+- [ ] [OC-SORT](https://arxiv.org/abs/2203.14360)  (arXiv 2022)
+
+支持的数据集：
+
+- [x] [MOT Challenge](https://motchallenge.net/)
+- [x] [CrowdHuman](https://www.crowdhuman.org/)
+- [x] [LVIS](https://www.lvisdataset.org/)
+- [x] [TAO](https://taodataset.org/)
+- [ ] [DanceTrack](https://arxiv.org/abs/2111.14690)
+- [ ] [BDD100k](https://arxiv.org/abs/1805.04687)
+
+### 视频实例分割
+
+支持的算法:
 
 - [x] [MaskTrack R-CNN](configs/vis/masktrack_rcnn) (ICCV 2019)
+- [ ] [Mask2Former](https://github.com/facebookresearch/Mask2Former) (CVPR 2022)
+
+支持的数据集：
+
+- [x] [YouTube-VIS](https://youtube-vos.org/dataset/vis/)
+- [ ] [OVIS](https://arxiv.org/abs/2102.01558)
 
 ## 安装
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -105,7 +105,6 @@ v0.13.0版本已于2022年04月29日发布，可通过查阅[更新日志](docs/
 
 - [x] [SORT/DeepSORT](configs/mot/deepsort) (ICIP 2016/2017)
 - [x] [Tracktor](configs/mot/tracktor) (ICCV 2019)
-- [ ] [CenterTrack](https://arxiv.org/abs/2004.01177) (ECCV 2020)
 - [x] [QDTrack](configs/mot/qdtrack) (CVPR 2021)
 - [x] [ByteTrack](configs/mot/bytetrack) (arXiv 2021)
 - [ ] [OC-SORT](https://arxiv.org/abs/2203.14360)  (arXiv 2022)
@@ -117,19 +116,16 @@ v0.13.0版本已于2022年04月29日发布，可通过查阅[更新日志](docs/
 - [x] [LVIS](https://www.lvisdataset.org/)
 - [x] [TAO](https://taodataset.org/)
 - [ ] [DanceTrack](https://arxiv.org/abs/2111.14690)
-- [ ] [BDD100k](https://arxiv.org/abs/1805.04687)
 
 ### 视频实例分割
 
 支持的算法:
 
 - [x] [MaskTrack R-CNN](configs/vis/masktrack_rcnn) (ICCV 2019)
-- [ ] [Mask2Former](https://github.com/facebookresearch/Mask2Former) (CVPR 2022)
 
 支持的数据集：
 
 - [x] [YouTube-VIS](https://youtube-vos.org/dataset/vis/)
-- [ ] [OVIS](https://arxiv.org/abs/2102.01558)
 
 ## 安装
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -89,7 +89,7 @@ v0.13.0版本已于2022年04月29日发布，可通过查阅[更新日志](docs/
 
 - [x] [SiameseRPN++](configs/sot/siamese_rpn) (CVPR 2019)
 - [x] [STARK](configs/sot/stark) (ICCV 2021)
-- [ ] [PrDiMP](https://arxiv.org/abs/2003.12565) (CVPR2020)
+- [ ] [PrDiMP](https://arxiv.org/abs/2003.12565) (CVPR2020) (WIP)
 
 支持的数据集：
 
@@ -108,7 +108,7 @@ v0.13.0版本已于2022年04月29日发布，可通过查阅[更新日志](docs/
 - [x] [Tracktor](configs/mot/tracktor) (ICCV 2019)
 - [x] [QDTrack](configs/mot/qdtrack) (CVPR 2021)
 - [x] [ByteTrack](configs/mot/bytetrack) (arXiv 2021)
-- [ ] [OC-SORT](https://arxiv.org/abs/2203.14360)  (arXiv 2022)
+- [ ] [OC-SORT](https://arxiv.org/abs/2203.14360)  (arXiv 2022) (WIP)
 
 支持的数据集：
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -89,6 +89,7 @@ v0.13.0版本已于2022年04月29日发布，可通过查阅[更新日志](docs/
 
 - [x] [SiameseRPN++](configs/sot/siamese_rpn) (CVPR 2019)
 - [x] [STARK](configs/sot/stark) (ICCV 2021)
+- [ ] [PrDiMP](https://arxiv.org/abs/2003.12565) (CVPR2020)
 
 支持的数据集：
 
@@ -115,7 +116,7 @@ v0.13.0版本已于2022年04月29日发布，可通过查阅[更新日志](docs/
 - [x] [CrowdHuman](https://www.crowdhuman.org/)
 - [x] [LVIS](https://www.lvisdataset.org/)
 - [x] [TAO](https://taodataset.org/)
-- [ ] [DanceTrack](https://arxiv.org/abs/2111.14690)
+- [x] [DanceTrack](https://arxiv.org/abs/2111.14690)
 
 ### 视频实例分割
 


### PR DESCRIPTION
I remake the gallery for supported/on-the-way methods and datasets in the README.

We should discuss the aesthetic preference of this version. I use emoji ⭕ and ✅ to indicate on-the-way and already supported entries. This is a workaround because the raw html tags `<input type="checkbox" />` and `<input type="checkbox"  checked />` for checkbox in the table are not supported by Github markdown standard. There are other alternatives such as ✔️. Or, we could make the table pure HTML coded instead of a markdown table, which will nicely support in-table checkbox.