### PR TITLE
[Fix] Fix a bug in the configuration file of QDTrack on LVIS dataset.

### DIFF
--- a/configs/mot/qdtrack/qdtrack_faster-rcnn_r101_fpn_24e_lvis.py
+++ b/configs/mot/qdtrack/qdtrack_faster-rcnn_r101_fpn_24e_lvis.py
@@ -1,6 +1,7 @@
 # model settings
 _base_ = [
-    './qdtrack_faster-rcnn_r50_fpn_4e_base.py', '../../_base_/datasets/tao.py'
+    '../../_base_/models/faster_rcnn_r50_fpn.py',
+    '../../_base_/datasets/tao.py', '../../_base_/default_runtime.py'
 ]
 model = dict(
     type='QDTrack',
@@ -17,10 +18,46 @@ model = dict(
             rcnn=dict(
                 score_thr=0.0001,
                 nms=dict(type='nms', iou_threshold=0.5),
-                max_per_img=300)),
-        init_cfg=None),
+                max_per_img=300))),
+    track_head=dict(
+        type='QuasiDenseTrackHead',
+        roi_extractor=dict(
+            type='SingleRoIExtractor',
+            roi_layer=dict(type='RoIAlign', output_size=7, sampling_ratio=0),
+            out_channels=256,
+            featmap_strides=[4, 8, 16, 32]),
+        embed_head=dict(
+            type='QuasiDenseEmbedHead',
+            num_convs=4,
+            num_fcs=1,
+            embed_channels=256,
+            norm_cfg=dict(type='GN', num_groups=32),
+            loss_track=dict(type='MultiPosCrossEntropyLoss', loss_weight=0.25),
+            loss_track_aux=dict(
+                type='L2Loss',
+                neg_pos_ub=3,
+                pos_margin=0,
+                neg_margin=0.1,
+                hard_mining=True,
+                loss_weight=1.0)),
+        loss_bbox=dict(type='L1Loss', loss_weight=1.0),
+        train_cfg=dict(
+            assigner=dict(
+                type='MaxIoUAssigner',
+                pos_iou_thr=0.7,
+                neg_iou_thr=0.3,
+                min_pos_iou=0.5,
+                match_low_quality=False,
+                ignore_iof_thr=-1),
+            sampler=dict(
+                type='CombinedSampler',
+                num=256,
+                pos_fraction=0.5,
+                neg_pos_ub=3,
+                add_gt_as_proposals=True,
+                pos_sampler=dict(type='InstanceBalancedPosSampler'),
+                neg_sampler=dict(type='RandomSampler')))),
     tracker=dict(
-        _delete_=True,
         type='QuasiDenseTAOTracker',
         init_score_thr=0.0001,
         obj_score_thr=0.0001,
@@ -33,6 +70,7 @@ model = dict(
         distractor_score_thr=0.5,
         match_metric='bisoftmax',
         match_with_cosine=True))
+
 # learning policy
 lr_config = dict(
     policy='step',

--- a/configs/mot/qdtrack/qdtrack_faster-rcnn_r101_fpn_24e_lvis.py
+++ b/configs/mot/qdtrack/qdtrack_faster-rcnn_r101_fpn_24e_lvis.py
@@ -1,63 +1,29 @@
 # model settings
 _base_ = [
-    '../../_base_/models/faster_rcnn_r50_fpn.py',
-    '../../_base_/datasets/tao.py', '../../_base_/default_runtime.py'
+    './qdtrack_faster-rcnn_r50_fpn_4e_base.py', '../../_base_/datasets/tao.py'
 ]
 model = dict(
     type='QDTrack',
     detector=dict(
         backbone=dict(
             depth=101,
+            norm_cfg=dict(requires_grad=True),
+            style='pytorch',
             init_cfg=dict(
                 type='Pretrained', checkpoint='torchvision://resnet101')),
+        rpn_head=dict(bbox_coder=dict(clip_border=True)),
         roi_head=dict(
-            bbox_head=dict(
-                loss_bbox=dict(type='L1Loss', loss_weight=1.0),
-                num_classes=482)),
+            bbox_head=dict(bbox_coder=dict(
+                clip_border=True), num_classes=482)),
         test_cfg=dict(
             rcnn=dict(
                 score_thr=0.0001,
                 nms=dict(type='nms', iou_threshold=0.5),
-                max_per_img=300))),
-    track_head=dict(
-        type='QuasiDenseTrackHead',
-        roi_extractor=dict(
-            type='SingleRoIExtractor',
-            roi_layer=dict(type='RoIAlign', output_size=7, sampling_ratio=0),
-            out_channels=256,
-            featmap_strides=[4, 8, 16, 32]),
-        embed_head=dict(
-            type='QuasiDenseEmbedHead',
-            num_convs=4,
-            num_fcs=1,
-            embed_channels=256,
-            norm_cfg=dict(type='GN', num_groups=32),
-            loss_track=dict(type='MultiPosCrossEntropyLoss', loss_weight=0.25),
-            loss_track_aux=dict(
-                type='L2Loss',
-                neg_pos_ub=3,
-                pos_margin=0,
-                neg_margin=0.1,
-                hard_mining=True,
-                loss_weight=1.0)),
-        loss_bbox=dict(type='L1Loss', loss_weight=1.0),
-        train_cfg=dict(
-            assigner=dict(
-                type='MaxIoUAssigner',
-                pos_iou_thr=0.7,
-                neg_iou_thr=0.3,
-                min_pos_iou=0.5,
-                match_low_quality=False,
-                ignore_iof_thr=-1),
-            sampler=dict(
-                type='CombinedSampler',
-                num=256,
-                pos_fraction=0.5,
-                neg_pos_ub=3,
-                add_gt_as_proposals=True,
-                pos_sampler=dict(type='InstanceBalancedPosSampler'),
-                neg_sampler=dict(type='RandomSampler')))),
+                max_per_img=300)),
+        init_cfg=None),
+    track_head=dict(train_cfg=dict(assigner=dict(neg_iou_thr=0.3))),
     tracker=dict(
+        _delete_=True,
         type='QuasiDenseTAOTracker',
         init_score_thr=0.0001,
         obj_score_thr=0.0001,


### PR DESCRIPTION
It is mainly to modify `config.py` to inherit directly from `fast_ rcnn_ r50_ fpn`，

Inherited from `qdtrack_faster-rcnn_r50_ fpn_ 4e_ base` will be inconvenient to modify some configuration keys, especially in the `detector` part, which directly inherits` fast_ rcnn_ r50_ fpn` feels more friendly.

At present, the cfg of the `master` branch will lead to differences in track AP on Tao (11.0/8.5).