### PR TITLE
Update video_sampler.py

### DIFF
--- a/mmtrack/datasets/samplers/video_sampler.py
+++ b/mmtrack/datasets/samplers/video_sampler.py
@@ -28,7 +28,7 @@ class SOTVideoSampler(Sampler):
 
     def __iter__(self):
         return iter(self.indices)
-    
+
     def __len__(self):
         return len(self.dataset)
 

--- a/mmtrack/datasets/samplers/video_sampler.py
+++ b/mmtrack/datasets/samplers/video_sampler.py
@@ -28,6 +28,9 @@ class SOTVideoSampler(Sampler):
 
     def __iter__(self):
         return iter(self.indices)
+    
+    def __len__(self):
+        return len(self.dataset)
 
 
 class DistributedVideoSampler(_DistributedSampler):


### PR DESCRIPTION
实现SOTVideoSamler的__len__方法，解决训练中途单卡测试时报TypeError: object of type 'SOTVideoSamler' has no len()的问题