### PR TITLE
[Fix] Fix bugs about cfg.gpu_ids in distributed training

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -10,7 +10,7 @@ import mmcv
 import torch
 import torch.distributed as dist
 from mmcv import Config, DictAction
-from mmcv.runner import init_dist
+from mmcv.runner import get_dist_info, init_dist
 from mmdet.apis import set_random_seed
 
 from mmtrack import __version__
@@ -135,6 +135,9 @@ def main():
     else:
         distributed = True
         init_dist(args.launcher, **cfg.dist_params)
+        # gpu_ids is used to calculate iter when resuming checkpoint,
+        _, world_size = get_dist_info()
+        cfg.gpu_ids = range(world_size)
 
     # create work_dir
     mmcv.mkdir_or_exist(osp.abspath(cfg.work_dir))


### PR DESCRIPTION
As shown in  
https://github.com/open-mmlab/mmcv/blob/04ec054e6b32f31b7f475304828706dc70844972/mmcv/runner/base_runner.py#L387
 , `cfg.gpu_ids` are used to calculate `self._iter`  when resuming checkpoint in distributed train. But it is set to `range(1)` by default, which lead to incorrect `self._iter` and potentially cause incorrect values which are calculated based on `runner.iter` (e.g., the learning rate in some lr scheduler.)

Similar bug has been found and fixed in mmseg (https://github.com/open-mmlab/mmsegmentation/pull/866#issue-992831656)