### PR TITLE
[Fix] Fix bugs in CMC model

### DIFF
--- a/mmtrack/models/motion/camera_motion_compensation.py
+++ b/mmtrack/models/motion/camera_motion_compensation.py
@@ -29,8 +29,9 @@ class CameraMotionCompensation:
 
     def get_warp_matrix(self, img: np.ndarray, ref_img: np.ndarray) -> Tensor:
         """Calculate warping matrix between two images."""
-        img = cv2.cvtColor(img, cv2.COLOR_RGB2GRAY)
-        ref_img = cv2.cvtColor(ref_img, cv2.COLOR_RGB2GRAY)
+        img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+        ref_img = cv2.cvtColor(ref_img, cv2.COLOR_BGR2GRAY)
+
 
         warp_matrix = np.eye(2, 3, dtype=np.float32)
         criteria = (cv2.TERM_CRITERIA_EPS | cv2.TERM_CRITERIA_COUNT,

--- a/mmtrack/models/motion/camera_motion_compensation.py
+++ b/mmtrack/models/motion/camera_motion_compensation.py
@@ -32,7 +32,6 @@ class CameraMotionCompensation:
         img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
         ref_img = cv2.cvtColor(ref_img, cv2.COLOR_BGR2GRAY)
 
-
         warp_matrix = np.eye(2, 3, dtype=np.float32)
         criteria = (cv2.TERM_CRITERIA_EPS | cv2.TERM_CRITERIA_COUNT,
                     self.num_iters, self.stop_eps)

--- a/mmtrack/models/motion/camera_motion_compensation.py
+++ b/mmtrack/models/motion/camera_motion_compensation.py
@@ -64,11 +64,16 @@ class CameraMotionCompensation:
         return means
 
     def track(self, img: Tensor, ref_img: Tensor, tracks: dict,
-              num_samples: int, frame_id: int) -> dict:
+              num_samples: int, frame_id: int, metainfo: dict) -> dict:
         """Tracking forward."""
         img = img.squeeze(0).cpu().numpy().transpose((1, 2, 0))
         ref_img = ref_img.squeeze(0).cpu().numpy().transpose((1, 2, 0))
         warp_matrix = self.get_warp_matrix(img, ref_img)
+
+        # rescale the warp_matrix due to the `resize` in pipeline
+        scale_factor_h, scale_factor_w = metainfo['scale_factor']
+        warp_matrix[0, 2] = warp_matrix[0, 2] / scale_factor_w
+        warp_matrix[1, 2] = warp_matrix[1, 2] / scale_factor_h
 
         bboxes = []
         num_bboxes = []

--- a/mmtrack/models/trackers/strongsort_tracker.py
+++ b/mmtrack/models/trackers/strongsort_tracker.py
@@ -171,7 +171,7 @@ class StrongSORTTracker(SORTTracker):
             if model.with_cmc:
                 num_samples = 1
                 self.tracks = model.cmc.track(self.last_img, img, self.tracks,
-                                              num_samples, frame_id)
+                                              num_samples, frame_id, metainfo)
 
             self.tracks, motion_dists = model.kalman.track(
                 self.tracks, bbox_xyxy_to_cxcyah(bboxes))

--- a/mmtrack/models/trackers/tracktor_tracker.py
+++ b/mmtrack/models/trackers/tracktor_tracker.py
@@ -182,7 +182,7 @@ class TracktorTracker(BaseTracker):
                 else:
                     num_samples = 1
                 self.tracks = model.cmc.track(self.last_img, img, self.tracks,
-                                              num_samples, frame_id)
+                                              num_samples, frame_id, metainfo)
 
             if model.with_linear_motion:
                 self.tracks = model.linear_motion.track(self.tracks, frame_id)


### PR DESCRIPTION
This PR fixes some bugs in the CMC model according to #763.

To be specific:
- fix v1: The original cmc model only change the `track.bboxes`, rather than `track.mean`, which means CMC will don't influence the stage-1 association of StrongSORT. Therefore, I add the missing modifications on `track.mean` in this PR.
- fix v2: According to the codes from mmcv, https://github.com/open-mmlab/mmcv/blob/5f58b9101f959a5794860b2737ab83b522d25915/mmcv/transforms/loading.py#L69-L71 and https://github.com/open-mmlab/mmcv/blob/5f58b9101f959a5794860b2737ab83b522d25915/mmcv/image/io.py#L212-L215, the input image is of BGR type. However, it is treated as RGB in CMC. Therefore, I fix it.
- fix v3: Because the img is resized in test_pipeline, we need to rescale the warp_matrix while applyint CMC model.

The ablation results (HOTA/MOTA/IDF1) on MOT17-val is:
- original StrongSORT: 70.89 / 78.34 / 83.24
- fix v1: 71.02 / 78.27 / 83.46
- fix v2: 70.93 / 78.27 / 83.21
- fix v3: 70.93 / 78.27 / 83.38