### PR TITLE
[Feature] Support mmtrack with NPU backend.

### DIFF
--- a/mmtrack/utils/__init__.py
+++ b/mmtrack/utils/__init__.py
@@ -1,5 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from .collect_env import collect_env
 from .logger import get_root_logger
+from .util_distribution import build_ddp, build_dp, get_device
 
-__all__ = ['collect_env', 'get_root_logger']
+__all__ = [
+    'collect_env', 'get_root_logger', 'build_ddp', 'build_dp', 'get_device'
+]

--- a/mmtrack/utils/util_distribution.py
+++ b/mmtrack/utils/util_distribution.py
@@ -1,0 +1,71 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import torch
+from mmcv.parallel import MMDataParallel, MMDistributedDataParallel
+
+dp_factory = {'cuda': MMDataParallel, 'cpu': MMDataParallel}
+
+ddp_factory = {'cuda': MMDistributedDataParallel}
+
+
+def build_dp(model, device='cuda', dim=0, *args, **kwargs):
+    """build DataParallel module by device type.
+
+    if device is cuda, return a MMDataParallel model; if device is npu,
+    return a NPUDataParallel model.
+    Args:
+        model (:class:`nn.Module`): model to be parallelized.
+        device (str): device type, cuda, cpu or npu. Defaults to cuda.
+        dim (int): Dimension used to scatter the data. Defaults to 0.
+    Returns:
+        nn.Module: the model to be parallelized.
+    """
+    if device == 'npu':
+        from mmcv.device.npu import NPUDataParallel
+        dp_factory['npu'] = NPUDataParallel
+        torch.npu.set_device(kwargs['device_ids'][0])
+        torch.npu.set_compile_mode(jit_compile=False)
+        model = model.npu()
+    elif device == 'cuda':
+        model = model.cuda(kwargs['device_ids'][0])
+
+    return dp_factory[device](model, dim=dim, *args, **kwargs)
+
+
+def build_ddp(model, device='cuda', *args, **kwargs):
+    """Build DistributedDataParallel module by device type.
+    If device is cuda, return a MMDistributedDataParallel model;
+    if device is npu, return a NPUDistributedDataParallel model.
+    Args:
+        model (:class:`nn.Module`): module to be parallelized.
+        device (str): device type, npu or cuda.
+    Returns:
+        :class:`nn.Module`: the module to be parallelized
+    References:
+        .. [1] https://pytorch.org/docs/stable/generated/torch.nn.parallel.
+                     DistributedDataParallel.html
+    """
+    assert device in ['cuda', 'npu'], 'Only available for cuda or npu devices.'
+    if device == 'npu':
+        from mmcv.device.npu import NPUDistributedDataParallel
+        torch.npu.set_compile_mode(jit_compile=False)
+        ddp_factory['npu'] = NPUDistributedDataParallel
+        model = model.npu()
+    elif device == 'cuda':
+        model = model.cuda()
+
+    return ddp_factory[device](model, *args, **kwargs)
+
+
+def is_npu_available():
+    """Returns a bool indicating if NPU is currently available."""
+    return hasattr(torch, 'npu') and torch.npu.is_available()
+
+
+def get_device():
+    """Returns an available device, cpu, cuda or npu."""
+    is_device_available = {
+        'npu': is_npu_available(),
+        'cuda': torch.cuda.is_available()
+    }
+    device_list = [k for k, v in is_device_available.items() if v]
+    return device_list[0] if len(device_list) >= 1 else 'cpu'

--- a/tools/train.py
+++ b/tools/train.py
@@ -17,7 +17,7 @@ from mmtrack import __version__
 from mmtrack.apis import init_random_seed
 from mmtrack.core import setup_multi_processes
 from mmtrack.datasets import build_dataset
-from mmtrack.utils import collect_env, get_root_logger
+from mmtrack.utils import collect_env, get_device, get_root_logger
 
 
 def parse_args():
@@ -165,16 +165,19 @@ def main():
 
     # set random seeds. Force setting fixed seed and deterministic=True in SOT
     # configs
+    cfg.device = get_device() if cfg.get('device',
+                                         None) is None else cfg.device
     if args.seed is not None:
         cfg.seed = args.seed
     elif cfg.get('seed', None) is None:
-        cfg.seed = init_random_seed()
+        cfg.seed = init_random_seed(device=cfg.device)
     cfg.seed = cfg.seed + dist.get_rank() if args.diff_seed else cfg.seed
 
     deterministic = True if args.deterministic else cfg.get(
         'deterministic', False)
     logger.info(f'Set random seed to {cfg.seed}, '
                 f'deterministic: {deterministic}')
+
     set_random_seed(cfg.seed, deterministic=deterministic)
     meta['seed'] = cfg.seed
 


### PR DESCRIPTION
## Motivation

Added ascending device support in mmtracking.

## Modification

The main modification points are as follows:
   We added an NPU device in the DDP scenario and DP scenario when using the NPU.

## Use cases (Optional)

We tested configs/reid/resnet50_b32x8_MOT17.py  in the DDP scenario and DP scenario.

cuda: 
train
![image](https://user-images.githubusercontent.com/50576385/234274318-4678f9f9-3c5a-474e-88ad-81d86f0a1926.png)
test
![image](https://user-images.githubusercontent.com/50576385/234274215-173fd03a-d17f-4f3f-aea8-ab4383b09dcd.png)


npu:
train
![image](https://user-images.githubusercontent.com/50576385/234272738-0430f5cf-8fa2-428d-80dc-560267d0e66a.png)
test
![image](https://user-images.githubusercontent.com/50576385/234269852-26cf71c3-38b5-403a-aa66-47a34263efa9.png)


cpu:
train
![image](https://user-images.githubusercontent.com/50576385/234273308-b97880e7-3b1a-4d37-9c9e-50f052e80581.png)
test
![image](https://user-images.githubusercontent.com/50576385/234269828-2ad8360a-0dfa-47af-9b68-f8011894409f.png)


