### PR TITLE
Add OpenXLab badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 [![badge](https://github.com/open-mmlab/mmtracking/workflows/build/badge.svg)](https://github.com/open-mmlab/mmtracking/actions)
 [![codecov](https://codecov.io/gh/open-mmlab/mmtracking/branch/master/graph/badge.svg)](https://codecov.io/gh/open-mmlab/mmtracking)
 [![license](https://img.shields.io/github/license/open-mmlab/mmtracking.svg)](https://github.com/open-mmlab/mmtracking/blob/master/LICENSE)
+[![Open in OpenXLab](https://cdn-static.openxlab.org.cn/app-center/openxlab_demo.svg)](https://openxlab.org.cn/apps?search=mmtrack)
 
 [📘Documentation](https://mmtracking.readthedocs.io/en/1.x/) |
 [🛠️Installation](https://mmtracking.readthedocs.io/en/1.x/get_started.html) |


### PR DESCRIPTION
Add OpenXLab Badge to share official applications, community applications and ecological applications based on MMTracking in the OpenXLab platform.